### PR TITLE
Honor the layout parameter to tiledbcloud::execute_array_udf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ vignettes/*.pdf
 
 # Local files
 local/*
+
+# Vim swapfiles
+.sw?
+.*.sw?

--- a/R/execute.R
+++ b/R/execute.R
@@ -106,8 +106,9 @@ execute_array_udf <- function(namespace, array, udf, selectedRanges, attrs=NULL,
   # At the user/library level this is a list of two-column matrices, e.g.
   # 'list(cbind(1,2), cbind(3,4))'.
 
-  # TODO: parameterize from the argument list.
-  layout <- Layout$new('row-major')
+  if (!is.null(layout)) {
+    layout <- Layout$new(layout)
+  }
 
   queryRanges <- QueryRanges$new(layout=layout, ranges=selectedRanges)
   multi_array_udf$ranges = queryRanges


### PR DESCRIPTION
Validation:

```
#!/usr/bin/env Rscript

library(tiledbcloud)
library(tiledb)

# Re-use cached tiledbcloud::login from run of another script, via ~/.tiledb/cloud.json

namespace  <- "demo"
array_name <- "quickstart_dense"

myfunc <- function(df) {
  vec <- as.vector(df[["a"]])
  list(min=min(vec), med=median(vec), max=max(vec))
}

selectedRanges <- list(cbind(1,2), cbind(1,2))
attrs <- c("a")
layouts <- list("row-major", "col-major", "global-order", "unordered", "this-is-invalid")

for (layout in layouts) {
  cat("LAYOUT", layout, ":\n")
  result <- tiledbcloud::execute_array_udf(
    namespace=namespace,
    array=array_name,
    udf=myfunc,
    selectedRanges=selectedRanges,
    attrs=attrs,
    layout=layout
  )
  print(result)
}
```

Output:

```
LAYOUT row-major :
$min
[1] 1

$med
[1] 3.5

$max
[1] 6

LAYOUT col-major :
$min
[1] 1

$med
[1] 3.5

$max
[1] 6

LAYOUT global-order :
$min
[1] 1

$med
[1] 3.5

$max
[1] 6

LAYOUT unordered :
$min
[1] 1

$med
[1] 3.5

$max
[1] 6

LAYOUT this-is-invalid :
Error in initialize(...) :
  Use one of the valid values: row-major, col-major, global-order, unordered
Calls: <Anonymous> -> <Anonymous> -> initialize
Execution halted
```