### PR TITLE
Support re-login after remember_me=FALSE

### DIFF
--- a/R/configure.R
+++ b/R/configure.R
@@ -44,7 +44,13 @@ configure <- function() {
         if ("username" %in% names(cfg))  username <- cfg$username
         if ("password" %in% names(cfg))  password <- cfg$password
         if (host == "")  host <- gsub("/v1(/)?$", "", cfg$host) # scrubs trailing /v1 or /v1/
-        if (token == "" && !is.null(cfg$api_key[[1]])) token <- cfg$api_key[[1]]
+        # If the previous login was without a session-token requested then the cloud-config
+        # JSON file will have username and password but no API key.
+        if (token == "") {
+          if (!is.null(cfg$api_key) && length(cfg$api_key) > 0 && !is.null(cfg$api_key[[1]])) {
+              token <- cfg$api_key[[1]]
+          }
+        }
         verify_ssl <- cfg$verify_ssl
     }
 

--- a/R/login.R
+++ b/R/login.R
@@ -57,14 +57,18 @@ login <- function(username, password, api_key, host, remember_me=TRUE) {
 
     ## if there is not api token key, request one
     if (api_key == "") {
-        ## request a session
+        ## request a session ...
         sess <- api$GetSession(remember.me = remember_me)
 
-        ## and proceed with the assigned token
+        ## ... and proceed with the assigned token ...
         api_key <- sess$token
         api$apiClient$apiKeys['X-TILEDB-REST-API-KEY'] <- api_key
-        ## and store it
-        .setConfigValue("api_key", api_key)
+        ## ... and store it.
+        ## note that the user can request a sessionless login so we
+        ## check for null here.
+        if (!is.null(api_key)) {
+          .setConfigValue("api_key", api_key)
+        }
     }
 
     ## use as a possible test


### PR DESCRIPTION
`TileDB-Cloud-Py` reads `~/.tiledb/cloud.json` file after previous `tiledb.cloud.login`, _and_ writes `~/.tiledb/cloud.json`.

Currently `TileDB-Cloud-R` reads `~/.tiledb/cloud.json` file after previous `tiledb.cloud.login`, but doesn't (yet) `~/.tiledb/cloud.json`.

If the user does Python `tiledb.cloud.login()` with keyword `no_session=True` then there will be no `api_key` in `~/.tiledb/cloud.json` so we should handle that here in R.

This is a bit of a corner case but it's useful for dev/testing.