### PR TITLE
Let array UDFs take additional arguments

### DIFF
--- a/man/execute_array_udf.Rd
+++ b/man/execute_array_udf.Rd
@@ -11,6 +11,7 @@ execute_array_udf(
   selectedRanges,
   attrs = NULL,
   layout = NULL,
+  args = NULL,
   result_format = "native"
 )
 }
@@ -29,6 +30,11 @@ each matrix being a start-end pair: e.g. \code{list(cbind(1,10),cbind(1,20))}.}
 
 \item{layout}{One of \code{row-major}, \code{col-major}, \code{global-order}, or
 \code{unordered},}
+
+\item{args}{Arguments to the function. If the function takes
+no arguments, this can be omitted. If you want to call by
+position, use a list like \code{args=list(123, 456)}. If you want
+to call by name, use a named list like \code{args=list(x=123,y=456)}.}
 
 \item{result_format}{One of \code{native}, \code{json}, or \code{arrow}. These are
 used as wire format for returning results from the server to this library, primarily

--- a/man/execute_multi_array_udf.Rd
+++ b/man/execute_multi_array_udf.Rd
@@ -4,7 +4,13 @@
 \alias{execute_multi_array_udf}
 \title{TileDB Cloud UDF-Execution Helper for multiple-array UDFs}
 \usage{
-execute_multi_array_udf(namespace, array_list, udf, result_format = NULL)
+execute_multi_array_udf(
+  namespace,
+  array_list,
+  udf,
+  args = NULL,
+  result_format = NULL
+)
 }
 \arguments{
 \item{namespace}{Namespace within TileDB cloud.}
@@ -13,6 +19,11 @@ execute_multi_array_udf(namespace, array_list, udf, result_format = NULL)
 Example list element: \code{tiledbcloud::UDFArrayDetails$new(uri="tiledb://demo/quickstart_dense", ranges=QueryRanges$new(layout=Layout$new('row-major'), ranges=list(cbind(1,4),cbind(1,4))), buffers=list("a"))}}
 
 \item{udf}{An R function which takes dataframes as arguments, one dataframe argument for each element in \code{array_list}.}
+
+\item{args}{Arguments to the function. If the function takes
+no arguments, this can be omitted. If you want to call by
+position, use a list like \code{args=list(123, 456)}. If you want
+to call by name, use a named list like \code{args=list(x=123,y=456)}.}
 
 \item{result_format}{One of \code{native}, \code{json}, or \code{arrow}. These are
 used as wire format for returning results from the server to this library, primarily


### PR DESCRIPTION
Continued work on SC 10789.

# Validation

```
library(tiledb)
library(tiledbcloud)

# Not doing tiledbcloud::login here; re-using ~/.tiledb/cloud.json.
namespace <- "demo"
array_name <- "quickstart_dense"

myfunc <- function(df, exponent) {
  vec <- as.vector(df[["a"]])
  sum(vec) ** exponent
}

selectedRanges <- list(cbind(1,4), cbind(1,4))
attrs <- c("a")

result <- tiledbcloud::execute_array_udf(
  namespace=namespace,
  array=array_name,
  udf=myfunc,
  selectedRanges=selectedRanges,
  attrs=attrs,
  args=list(exponent=2)
)
print(result)

result <- tiledbcloud::execute_array_udf(
  namespace=namespace,
  array=array_name,
  udf=myfunc,
  selectedRanges=selectedRanges,
  attrs=attrs,
  args=list(exponent=3)
)
print(result)
```
outputs
```
[1] 18496
[1] 2515456
```
which makes sense since `quickstart_dense` is a 4x4 of numbers `1:16`, and `sum(1:16)**2` is 18496 while `sum(1:16)**3` is 2515456.

This is in line with current Python expectations via

```
import tiledb, tiledb.cloud, numpy

def median(df, exponent=1.0):
  return numpy.sum(df["a"]) ** exponent

namespace = "demo"
array_name = "quickstart_dense"
uri = "tiledb://%s/%s" % (namespace, array_name)

with tiledb.open(uri, ctx=tiledb.cloud.Ctx()) as A:
    print(A.apply(median, [[(1,4)], (1,4)], attrs=["a"], exponent=2.0))
    print(A.apply(median, [[(1,4)], (1,4)], attrs=["a"], exponent=3.0))
```