### PR TITLE
Make howtos vignettes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,18 +2,16 @@ Package: tiledbcloud
 Type: Package
 Title: TileDB Cloud Platform R Client Package
 Version: 0.0.4
-Authors@R: c(
-  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role="cre"),
-  person("John", "Kerl", email = "john.kerl@tiledb.com", role="aut"),
-  person("OpenAPI Generator community", email = "team@openapitools.org", role = "aut"))
-Copyright: TileDB, Inc.
+Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
+             person("OpenAPI Generator community", email = "team@openapitools.org", role = "ctb"),
+             person("John", "Kerl", email = "john.kerl@tiledb.com", role="cre"))
 Description: The TileDB Cloud Platform API Client Package offers access to the TileDB Cloud service.
 URL: https://github.com/TileDB-Inc/TileDB-Cloud-R
 BugReports: https://github.com/TileDB-Inc/TileDB-Cloud-R/issues
 Depends: R (>= 3.3)
 License: MIT + file LICENSE
-LazyData: true
-Suggests: testthat, tinytest
+Suggests: testthat, tinytest, rmarkdown, knitr
 Imports: jsonlite, arrow, httr, R6, base64enc
+VignetteBuilder: knitr
 Encoding: UTF-8
 RoxygenNote: 7.1.2

--- a/vignettes/HowToBuild.Rmd
+++ b/vignettes/HowToBuild.Rmd
@@ -1,3 +1,12 @@
+---
+title: "How To Build"
+output: github_document
+vignette: |
+  %\VignetteIndexEntry{How To Build}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
 # How to build this package
 
 ## Build and Test

--- a/vignettes/HowToRelease.Rmd
+++ b/vignettes/HowToRelease.Rmd
@@ -1,3 +1,12 @@
+---
+title: "How To Release"
+output: github_document
+vignette: |
+  %\VignetteIndexEntry{How To Release}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
 # How to release a version
 
 * Bump version number in [DESCRIPTION](./DESCRIPTION)

--- a/vignettes/HowToUpdateAPI.Rmd
+++ b/vignettes/HowToUpdateAPI.Rmd
@@ -1,3 +1,12 @@
+---
+title: "How To Update"
+output: github_document
+vignette: |
+  %\VignetteIndexEntry{How To Update}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
 # How to update from API spec
 
 These are the steps to follow when bringing this repo up to date from an updated [API spec](https://github.com/TileDB-Inc/TileDB-Cloud-API-Spec/blob/master/openapi-v1.yaml).


### PR DESCRIPTION
Small and quick PR to address two or three tiny issues:

- Authors@R wasn't quite right; there has to be _one_ `cre` element, and that should probably be you; also TileDB as copyright holder (and author for all of us) goes in there too
- LazyData was unused / unneeded (`R CMD check` nag)
- The markdown HOWTOs are now (trivial) vignettes and the machinery for that has been added to `DESCRIPTION` 

Feel free to use or discard as you see fit.
