### PR TITLE
Fix charge-vs-storage namespacing for single-array UDFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ local/*
 # Vim swapfiles
 .sw?
 .*.sw?
+
+# ctags files
+tags

--- a/R/manual_layer_utilities.r
+++ b/R/manual_layer_utilities.r
@@ -1,0 +1,9 @@
+# Splits input of the form "tiledb://foo/bar" or "foo/bar" into namespace="foo" and name="bar".
+.split_uri <- function(input) {
+  no_prefix <- sub("^tiledb://", "", input)
+  fields <- strsplit(no_prefix, split="/")
+  if (length(fields[[1]]) != 2) {
+    stop('URI input must be of form "tiledb://namespace/name", or "namespace/name"; got ', input)
+  }
+  list(namespace=fields[[1]][[1]], name=fields[[1]][[2]])
+}

--- a/R/udf_api.R
+++ b/R/udf_api.R
@@ -954,9 +954,15 @@ UdfApi <- R6::R6Class(
         stop("Missing required parameter `udf`.")
       }
 
-      headerParams['X-Payer'] <- `x.payer`
+      if (!missing(`x.payer`)) {
+        headerParams['X-Payer'] <- `x.payer`
+      }
 
-      headerParams['Accept-Encoding'] <- `accept.encoding`
+      # Without this we get
+      # 'Error in headerParams["Accept-Encoding"] <- accept.encoding : replacement has length zero'
+      if (!is.null(`accept.encoding`)) {
+        headerParams['Accept-Encoding'] <- accept.encoding
+      }
 
       queryParams['v2'] <- v2
 

--- a/docs/articles/UDFs.html
+++ b/docs/articles/UDFs.html
@@ -108,23 +108,17 @@ print(result)</code></pre>
 <div id="single-array-udfs" class="section level1">
 <h1 class="hasAnchor">
 <a href="#single-array-udfs" class="anchor"></a>Single-array UDFs</h1>
-<pre><code>namespace  &lt;- "demo"
-array_name &lt;- "quickstart_dense"
-myfunc &lt;- function(df) {
-  vec &lt;- as.vector(df[["a"]])
-  list(min=min(vec), med=median(vec), max=max(vec))
+<pre><code>myfunc &lt;- function(df) {
+    vec &lt;- as.vector(df[["a"]])
+    list(min=min(vec), med=median(vec), max=max(vec))
 }
 
-# Upper-left 2x2
-selectedRanges &lt;- list(cbind(1,2), cbind(1,2))
-attrs &lt;- c("a")
-
 result &lt;- tiledbcloud::execute_array_udf(
-  namespace=namespace,
-  array=array_name,
-  udf=myfunc,
-  selectedRanges=selectedRanges,
-  attrs=attrs
+    namespace="demo", // to charge
+    array="tiledb://TileDB-Inc/quickstart_dense",
+    udf=myfunc,
+    selectedRanges=list(cbind(1,2), cbind(1,2)), # Upper-left 2x2
+    attrs=c("a")
 )
 print(result)</code></pre>
 <pre><code>$min
@@ -135,25 +129,19 @@ $med
 
 $max
 [1] 6</code></pre>
-<pre><code>namespace  &lt;- "demo"
-array_name &lt;- "palmer_penguins2"
-
-# Run a linear regression on bill length vs body mass
+<pre><code># Run a linear regression on bill length vs body mass
 myfunc &lt;- function(df) {
   vec1 &lt;- as.vector(df$bill_length_mm)
   vec2 &lt;- as.vector(df$body_mass_g)
   lm.fit(cbind(1, vec2), vec1)$coefficients
 }
 
-selectedRanges &lt;- list(cbind("A", "Z"), cbind(2007,2009))
-attrs &lt;- list("bill_length_mm", "body_mass_g")
-
 result &lt;- tiledbcloud::execute_array_udf(
-    namespace=namespace,
-    array=array_name,
+    # NULL namespace means username namespace is charged
+    array="tiledb://demo/palmer_penguins2",
     udf=myfunc,
-    selectedRanges=selectedRanges,
-    attrs=attrs
+    selectedRanges=list(cbind("A", "Z"), cbind(2007,2009)),
+    attrs=list("bill_length_mm", "body_mass_g")
 )
 print(result)</code></pre>
 <pre><code>                   vec2
@@ -162,14 +150,7 @@ print(result)</code></pre>
 <div id="multi-array-udfs" class="section level1">
 <h1 class="hasAnchor">
 <a href="#multi-array-udfs" class="anchor"></a>Multi-array UDFs</h1>
-<pre><code>namespace   &lt;- "demo"
-array_name1 &lt;- "quickstart_dense"
-array_name2 &lt;- "quickstart_sparse"
-
-uri1 &lt;- paste("tiledb:/", namespace, array_name1, sep="/")
-uri2 &lt;- paste("tiledb:/", namespace, array_name2, sep="/")
-
-myfunc &lt;- function(df1, df2) {
+<pre><code>myfunc &lt;- function(df1, df2) {
   vec1 &lt;- as.vector(df1[["a"]])
   vec2 &lt;- as.vector(df2[["a"]])
   list(
@@ -181,7 +162,7 @@ myfunc &lt;- function(df1, df2) {
 }
 
 details1 &lt;- tiledbcloud::UDFArrayDetails$new(
-  uri=uri1,
+  uri="tiledb://TileDB-Inc/quickstart_dense",
   ranges=QueryRanges$new(
     layout=Layout$new('row-major'),
     ranges=list(cbind(1,4),cbind(1,4))
@@ -190,7 +171,7 @@ details1 &lt;- tiledbcloud::UDFArrayDetails$new(
 )
 
 details2 &lt;- tiledbcloud::UDFArrayDetails$new(
-  uri=uri2,
+  uri="tiledb://TileDB-Inc/quickstart_sparse",
   ranges=QueryRanges$new(
     layout=Layout$new('row-major'),
     ranges=list(cbind(1,2),cbind(1,4))
@@ -199,9 +180,9 @@ details2 &lt;- tiledbcloud::UDFArrayDetails$new(
 )
 
 result &lt;- tiledbcloud::execute_multi_array_udf(
-  namespace=namespace,
+  namespace="demo",
   array_list=list(details1, details2),
-  udf=myfunc,
+  udf=myfunc
 )
 print(result)</code></pre>
 <pre><code>$len

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -12,5 +12,5 @@ articles:
   Setup: Setup.html
   Tasks: Tasks.html
   UDFs: UDFs.html
-last_built: 2021-12-15T17:59Z
+last_built: 2021-12-15T21:16Z
 

--- a/docs/reference/execute_array_udf.html
+++ b/docs/reference/execute_array_udf.html
@@ -121,8 +121,8 @@
     </div>
 
     <pre class="usage"><span class='fu'>execute_array_udf</span><span class='op'>(</span>
-  <span class='va'>namespace</span>,
   <span class='va'>array</span>,
+  namespace <span class='op'>=</span> <span class='cn'>NULL</span>,
   udf <span class='op'>=</span> <span class='cn'>NULL</span>,
   registered_udf_name <span class='op'>=</span> <span class='cn'>NULL</span>,
   <span class='va'>selectedRanges</span>,
@@ -136,13 +136,14 @@
     <table class="ref-arguments">
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
-      <th>namespace</th>
-      <td><p>Namespace within TileDB cloud.</p></td>
+      <th>array</th>
+      <td><p>Name of the array, in the form either <code>tiledb://hello/world</code>
+or <code>hello/world</code>.</p></td>
     </tr>
     <tr>
-      <th>array</th>
-      <td><p>Name of the array. E.g. if the URI is <code>tiledb://hello/world</code>
-then the namespace is <code>hello</code> and the array is <code>world</code>.</p></td>
+      <th>namespace</th>
+      <td><p>Namespace within TileDB cloud to charge. If this is null, the
+logged-in user's username will be used for the namespace.</p></td>
     </tr>
     <tr>
       <th>udf</th>

--- a/man/execute_array_udf.Rd
+++ b/man/execute_array_udf.Rd
@@ -5,8 +5,8 @@
 \title{Execute a single-array UDF on TileDB Cloud}
 \usage{
 execute_array_udf(
-  namespace,
   array,
+  namespace = NULL,
   udf = NULL,
   registered_udf_name = NULL,
   selectedRanges,
@@ -17,10 +17,11 @@ execute_array_udf(
 )
 }
 \arguments{
-\item{namespace}{Namespace within TileDB cloud.}
+\item{array}{Name of the array, in the form either \code{tiledb://hello/world}
+or \code{hello/world}.}
 
-\item{array}{Name of the array. E.g. if the URI is \code{tiledb://hello/world}
-then the namespace is \code{hello} and the array is \code{world}.}
+\item{namespace}{Namespace within TileDB cloud to charge. If this is null, the
+logged-in user's username will be used for the namespace.}
 
 \item{udf}{An R function which takes a dataframe as argument.
 Arguments are specified separately via \code{args}.

--- a/vignettes/UDFs.Rmd
+++ b/vignettes/UDFs.Rmd
@@ -46,23 +46,17 @@ print(result)
 # Single-array UDFs
 
 ```
-namespace  <- "demo"
-array_name <- "quickstart_dense"
 myfunc <- function(df) {
-  vec <- as.vector(df[["a"]])
-  list(min=min(vec), med=median(vec), max=max(vec))
+    vec <- as.vector(df[["a"]])
+    list(min=min(vec), med=median(vec), max=max(vec))
 }
 
-# Upper-left 2x2
-selectedRanges <- list(cbind(1,2), cbind(1,2))
-attrs <- c("a")
-
 result <- tiledbcloud::execute_array_udf(
-  namespace=namespace,
-  array=array_name,
-  udf=myfunc,
-  selectedRanges=selectedRanges,
-  attrs=attrs
+    namespace="demo", // to charge
+    array="tiledb://TileDB-Inc/quickstart_dense",
+    udf=myfunc,
+    selectedRanges=list(cbind(1,2), cbind(1,2)), # Upper-left 2x2
+    attrs=c("a")
 )
 print(result)
 ```
@@ -79,9 +73,6 @@ $max
 ```
 
 ```
-namespace  <- "demo"
-array_name <- "palmer_penguins2"
-
 # Run a linear regression on bill length vs body mass
 myfunc <- function(df) {
   vec1 <- as.vector(df$bill_length_mm)
@@ -89,15 +80,12 @@ myfunc <- function(df) {
   lm.fit(cbind(1, vec2), vec1)$coefficients
 }
 
-selectedRanges <- list(cbind("A", "Z"), cbind(2007,2009))
-attrs <- list("bill_length_mm", "body_mass_g")
-
 result <- tiledbcloud::execute_array_udf(
-    namespace=namespace,
-    array=array_name,
+    # NULL namespace means username namespace is charged
+    array="tiledb://demo/palmer_penguins2",
     udf=myfunc,
-    selectedRanges=selectedRanges,
-    attrs=attrs
+    selectedRanges=list(cbind("A", "Z"), cbind(2007,2009)),
+    attrs=list("bill_length_mm", "body_mass_g")
 )
 print(result)
 ```
@@ -110,13 +98,6 @@ print(result)
 # Multi-array UDFs
 
 ```
-namespace   <- "demo"
-array_name1 <- "quickstart_dense"
-array_name2 <- "quickstart_sparse"
-
-uri1 <- paste("tiledb:/", namespace, array_name1, sep="/")
-uri2 <- paste("tiledb:/", namespace, array_name2, sep="/")
-
 myfunc <- function(df1, df2) {
   vec1 <- as.vector(df1[["a"]])
   vec2 <- as.vector(df2[["a"]])
@@ -129,7 +110,7 @@ myfunc <- function(df1, df2) {
 }
 
 details1 <- tiledbcloud::UDFArrayDetails$new(
-  uri=uri1,
+  uri="tiledb://TileDB-Inc/quickstart_dense",
   ranges=QueryRanges$new(
     layout=Layout$new('row-major'),
     ranges=list(cbind(1,4),cbind(1,4))
@@ -138,7 +119,7 @@ details1 <- tiledbcloud::UDFArrayDetails$new(
 )
 
 details2 <- tiledbcloud::UDFArrayDetails$new(
-  uri=uri2,
+  uri="tiledb://TileDB-Inc/quickstart_sparse",
   ranges=QueryRanges$new(
     layout=Layout$new('row-major'),
     ranges=list(cbind(1,2),cbind(1,4))
@@ -147,9 +128,9 @@ details2 <- tiledbcloud::UDFArrayDetails$new(
 )
 
 result <- tiledbcloud::execute_multi_array_udf(
-  namespace=namespace,
+  namespace="demo",
   array_list=list(details1, details2),
-  udf=myfunc,
+  udf=myfunc
 )
 print(result)
 ```


### PR DESCRIPTION
# Summary

Before this we could not run single-array-UDF queries on arrays we did not own since the single `namespace` parameter was failing to be disambiguated.

# Validation

```
library(tiledbcloud)
library(tiledb)

myfunc <- function(df) {
  vec <- as.vector(df[["a"]])
  list(min=min(vec), med=median(vec), max=max(vec))
}

result <- tiledbcloud::execute_array_udf(
  namespace="johnkerl", # namespace to charge
  array="TileDB-Inc/quickstart_dense",
  udf=myfunc,
  selectedRanges=list(cbind(1,2), cbind(1,2)),
  attrs=c("a")
)
print(result)
```

```
$min
[1] 1

$med
[1] 3.5

$max
[1] 6
```

```
library(tiledbcloud)
library(tiledb)

myfunc <- function(df) {
  vec <- as.vector(df[["a"]])
  list(min=min(vec), med=median(vec), max=max(vec))
}

result <- tiledbcloud::execute_array_udf(
  array="tiledb://johnkerl/quickstart_dense",
  udf=myfunc,
  selectedRanges=list(cbind(1,2), cbind(1,2)),
  attrs=c("a")
)
print(result)
```

```
$min
[1] 1

$med
[1] 3.5

$max
[1] 6
```

```
library(tiledbcloud)
library(tiledb)

myfunc <- function(df) {
  vec <- as.vector(df[["a"]])
  list(min=min(vec), med=median(vec), max=max(vec))
}

result <- tiledbcloud::execute_array_udf(
  array="tiledb://TileDB-Inc/quickstart_dense",
  udf=myfunc,
  selectedRanges=list(cbind(1,2), cbind(1,2)),
  attrs=c("a")
)
print(result)
```

```
Error: tiledbcloud: received error response: Server returned 401 response status code. Message:  You are not allowed to charge queries to TileDB-Inc
Execution halted
```

all as desired.