### PR TITLE
Add doc caveat about which UDF-info fields are writeable vs readable

### DIFF
--- a/R/manual_layer_udf.R
+++ b/R/manual_layer_udf.R
@@ -376,6 +376,9 @@ update_udf_info <- function(namespace, name, type, func=NULL, func_text=NULL, ve
 ##' Get information about a UDF on TileDB Cloud
 ##'
 ##' Reads back information for a specified user-defined function on TileDB Cloud.
+##' Note that \code{version}, \code{image_name}, \code{exec}, and \code{exec_raw}
+##' are writable via \link{\code{register_udf}} but are not read back by this
+##' function.
 ##'
 ##' @param namespace Namespace for the UDF in TileDB Cloud, e.g. \code{mynamespace}.
 ##'

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -12,5 +12,5 @@ articles:
   Setup: Setup.html
   Tasks: Tasks.html
   UDFs: UDFs.html
-last_built: 2021-12-16T21:50Z
+last_built: 2021-12-17T15:56Z
 

--- a/docs/reference/get_udf_info.html
+++ b/docs/reference/get_udf_info.html
@@ -40,7 +40,10 @@
 
 
 <meta property="og:title" content="Get information about a UDF on TileDB Cloud — get_udf_info" />
-<meta property="og:description" content="Reads back information for a specified user-defined function on TileDB Cloud." />
+<meta property="og:description" content="Reads back information for a specified user-defined function on TileDB Cloud.
+Note that version, image_name, exec, and exec_raw
+are writable via register_udf but are not read back by this
+function." />
 
 
 
@@ -117,7 +120,10 @@
     </div>
 
     <div class="ref-description">
-    <p>Reads back information for a specified user-defined function on TileDB Cloud.</p>
+    <p>Reads back information for a specified user-defined function on TileDB Cloud.
+Note that <code>version</code>, <code>image_name</code>, <code>exec</code>, and <code>exec_raw</code>
+are writable via <code>register_udf</code> but are not read back by this
+function.</p>
     </div>
 
     <pre class="usage"><span class='fu'>get_udf_info</span><span class='op'>(</span><span class='va'>name</span>, <span class='va'>namespace</span><span class='op'>)</span></pre>

--- a/man/get_udf_info.Rd
+++ b/man/get_udf_info.Rd
@@ -16,6 +16,9 @@ List of key-value pairs of UDF information.
 }
 \description{
 Reads back information for a specified user-defined function on TileDB Cloud.
+Note that \code{version}, \code{image_name}, \code{exec}, and \code{exec_raw}
+are writable via \link{\code{register_udf}} but are not read back by this
+function.
 }
 \seealso{
 Other {manual-layer functions}: 


### PR DESCRIPTION
Solely an advisory note in `get_udf_info` documentation.