### PR TITLE
Optionally write ~/.tiledb/cloud.json at login

### DIFF
--- a/R/manual_layer_configure.R
+++ b/R/manual_layer_configure.R
@@ -16,7 +16,7 @@
 
 .storeConfig <- function(homedir=Sys.getenv("HOME")) {
     if (homedir == "") {
-        stop("No HOME environment variable or homedir value.", call .= FALSE)  # Windows ?
+        stop("No HOME environment variable or homedir value.", call. =FALSE)  # Windows ?
     }
     cfgfile <- file.path(homedir, ".tiledb", "cloud.json")
 

--- a/R/manual_layer_configure.R
+++ b/R/manual_layer_configure.R
@@ -58,10 +58,15 @@ configure <- function() {
     ## Fallback defaults
     if (host == "") host <- "https://api.tiledb.com"
 
-    configuration <- c(api_key    = token,
-                       username   = username,
-                       password   = password,
-                       host       = host,
-                       verify_ssl = verify_ssl,
-                       logged_in  = "FALSE")
+    # We use jsonlite to persist sessions. In turn, jsonlite::toJSON will *not*
+    # retain names if the configuration is a named vector. We must use a named
+    # list.  Example: toJSON(c(a=1,b=2)) is '[1,2]' (bad) but
+    # toJSON(list(a=1,b=2),auto_unbox=TRUE) is '{"a":1,"b":2}' (good).
+    configuration <- list(api_key    = token,
+                          username   = username,
+                          password   = password,
+                          host       = host,
+                          verify_ssl = verify_ssl,
+                          logged_in  = "FALSE")
+    configuration
 }

--- a/R/manual_layer_configure.R
+++ b/R/manual_layer_configure.R
@@ -14,11 +14,9 @@
     cfg <- jsonlite::fromJSON(cfgfile)
 }
 
-.storeConfig <- function() {
-    homedir <- Sys.getenv("HOME")
+.storeConfig <- function(homedir=Sys.getenv("HOME")) {
     if (homedir == "") {
-        warning("No HOME environment variable.")  # Windows ?
-        return(NULL)
+        stop("No HOME environment variable or homedir value.", call .= FALSE)  # Windows ?
     }
     cfgfile <- file.path(homedir, ".tiledb", "cloud.json")
 

--- a/R/manual_layer_configure.R
+++ b/R/manual_layer_configure.R
@@ -1,3 +1,4 @@
+
 .loadConfig <- function() {
     ## should we use rappdirs? follow the XDG_CONFIG_HOME?
     homedir <- Sys.getenv("HOME")
@@ -11,6 +12,24 @@
         return(invisible(NULL))
     }
     cfg <- jsonlite::fromJSON(cfgfile)
+}
+
+.storeConfig <- function() {
+    homedir <- Sys.getenv("HOME")
+    if (homedir == "") {
+        warning("No HOME environment variable.")  # Windows ?
+        return(NULL)
+    }
+    cfgfile <- file.path(homedir, ".tiledb", "cloud.json")
+
+    cfgdata <- jsonlite::toJSON(.pkgenv[["config"]], auto_unbox=TRUE, pretty=TRUE)
+
+    write(cfgdata, cfgfile)
+
+    verbose <- getOption("verbose", "false")
+    if (verbose) {
+      cat("Wrote", cfgfile, "\n")
+    }
 }
 
 ##' Configure TileDB Cloud

--- a/R/manual_layer_login.R
+++ b/R/manual_layer_login.R
@@ -29,12 +29,17 @@
 ##' @param remember_me A boolean to select a session with for 24 hours
 ##' instead of 8 hours, used only when a new session is requested.
 ##'
+##' @param write_config A boolean to write the login information
+##' to \code{~/.tiledb/cloud.json} from where it can be read for
+##' subsequent sessions. This is only done when requested by this
+##' parameter, which is \code{FALSE} by default.
+##'
 ##' @return Nothing is returned; the function is called for a side effect
 ##' of storing the values in the package environment.
 ##'
 ##' @family {manual-layer functions}
 ##' @export
-login <- function(username, password, api_key, host, remember_me=TRUE) {
+login <- function(username, password, api_key, host, remember_me=TRUE, write_config=FALSE) {
     if (missing(username)) username <- .getConfigValue("username")
     if (missing(password)) password <- .getConfigValue("password")
     if (missing(api_key))  api_key  <- .getConfigValue("api_key")
@@ -85,6 +90,10 @@ login <- function(username, password, api_key, host, remember_me=TRUE) {
     ## Cache API-client and user-API instances
     .pkgenv[["apiClientInstance"]]  <- apiClientInstance
     .pkgenv[["userApiInstance"]] <- userApiInstance
+
+    if (write_config) {
+      .storeConfig()
+    }
 
     invisible()
 }

--- a/docs/articles/Login.html
+++ b/docs/articles/Login.html
@@ -138,6 +138,8 @@ export TILEDB_REST_PASSWORD="your-password"</code></pre>
     "host": "https://api.tiledb.com/v1",
     "verify_ssl": true
 }</code></pre>
+<p>If you use the optional <code>write_config=TRUE</code> argument for <code><a href="../reference/login.html">tiledbcloud::login</a></code> then <code>~/.tiledb/cloud.json</code> will be written for you:</p>
+<pre><code>tiledbcloud::login(username="your-username", password="your-password", write_config=TRUE)</code></pre>
 </div>
 <div id="showing-user-profile" class="section level2">
 <h2 class="hasAnchor">

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -12,5 +12,5 @@ articles:
   Setup: Setup.html
   Tasks: Tasks.html
   UDFs: UDFs.html
-last_built: 2021-12-20T19:12Z
+last_built: 2021-12-20T19:19Z
 

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -12,5 +12,5 @@ articles:
   Setup: Setup.html
   Tasks: Tasks.html
   UDFs: UDFs.html
-last_built: 2021-12-17T15:56Z
+last_built: 2021-12-20T19:12Z
 

--- a/docs/reference/login.html
+++ b/docs/reference/login.html
@@ -122,7 +122,14 @@ package load." />
 package load.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>login</span><span class='op'>(</span><span class='va'>username</span>, <span class='va'>password</span>, <span class='va'>api_key</span>, <span class='va'>host</span>, remember_me <span class='op'>=</span> <span class='cn'>TRUE</span><span class='op'>)</span></pre>
+    <pre class="usage"><span class='fu'>login</span><span class='op'>(</span>
+  <span class='va'>username</span>,
+  <span class='va'>password</span>,
+  <span class='va'>api_key</span>,
+  <span class='va'>host</span>,
+  remember_me <span class='op'>=</span> <span class='cn'>TRUE</span>,
+  write_config <span class='op'>=</span> <span class='cn'>FALSE</span>
+<span class='op'>)</span></pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -150,6 +157,13 @@ used instead of username and password.</p></td>
       <th>remember_me</th>
       <td><p>A boolean to select a session with for 24 hours
 instead of 8 hours, used only when a new session is requested.</p></td>
+    </tr>
+    <tr>
+      <th>write_config</th>
+      <td><p>A boolean to write the login information
+to <code>~/.tiledb/cloud.json</code> from where it can be read for
+subsequent sessions. This is only done when requested by this
+parameter, which is <code>FALSE</code> by default.</p></td>
     </tr>
     </table>
 

--- a/man/login.Rd
+++ b/man/login.Rd
@@ -4,7 +4,14 @@
 \alias{login}
 \title{Log in to TileDB Cloud}
 \usage{
-login(username, password, api_key, host, remember_me = TRUE)
+login(
+  username,
+  password,
+  api_key,
+  host,
+  remember_me = TRUE,
+  write_config = FALSE
+)
 }
 \arguments{
 \item{username}{A character value with the username, if present
@@ -20,6 +27,11 @@ used instead of username and password.}
 
 \item{remember_me}{A boolean to select a session with for 24 hours
 instead of 8 hours, used only when a new session is requested.}
+
+\item{write_config}{A boolean to write the login information
+to \code{~/.tiledb/cloud.json} from where it can be read for
+subsequent sessions. This is only done when requested by this
+parameter, which is \code{FALSE} by default.}
 }
 \value{
 Nothing is returned; the function is called for a side effect

--- a/vignettes/Login.Rmd
+++ b/vignettes/Login.Rmd
@@ -86,6 +86,13 @@ or
 }
 ```
 
+If you use the optional `write_config=TRUE` argument for `tiledbcloud::login`
+then `~/.tiledb/cloud.json` will be written for you:
+
+```
+tiledbcloud::login(username="your-username", password="your-password", write_config=TRUE)
+```
+
 ## Showing user profile
 
 ```


### PR DESCRIPTION
This is similar behavior to what the Python package `TileDB-Cloud-Py` already does -- except, default out-of-package writes are a no-no for CRAN compatibility, and we may wish to someday submit this to CRAN. So, for `TileDB-Cloud-R`, updating `~/.tiledb/cloud.json` will be opt-in.