### PR TITLE
Port test suite to tinytest

### DIFF
--- a/R/manual_layer_login.R
+++ b/R/manual_layer_login.R
@@ -117,3 +117,8 @@ get_api_client_instance <- function() {
   }
   apiClientInstance
 }
+
+# This is a convenience function for testing.
+.logged_in <- function() {
+  !is.null(tiledbcloud:::.pkgenv[["apiClientInstance"]])
+}

--- a/R/manual_layer_udf.R
+++ b/R/manual_layer_udf.R
@@ -366,7 +366,7 @@ update_udf_info <- function(namespace, name, type, func=NULL, func_text=NULL, ve
     tags=tags
   )
 
-  resultObject <- udfApiInstance$UpdateUDFInfo(namespace, udfname, info)
+  resultObject <- udfApiInstance$UpdateUDFInfo(namespace, name, info)
 
   # Decode the result, expecting empty string.
   .get_empty_response_body_or_stop(resultObject)

--- a/inst/tinytest/test_array_info.R
+++ b/inst/tinytest/test_array_info.R
@@ -1,0 +1,26 @@
+if ((unitTestToken <- Sys.getenv("TILEDB_REST_UNIT_TEST_TOKEN")) != "") {
+    Sys.setenv("TILEDB_REST_TOKEN"=unitTestToken)
+} else {
+    if (!file.exists("~/.tiledb/cloud.json")) exit_file("No authentication")
+}
+
+if ((namespaceToCharge <- Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE")) == "") {
+    exit_file("No TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE in environment")
+}
+
+library(tiledbcloud)
+library(tinytest)
+
+# ----------------------------------------------------------------
+# This .pkgenv is managed opaquely by the manual-layer API.
+# However, it's nice to consult it as a logged-in check, and
+# for consistency with other test files in this package.
+apiClientInstance <- tiledbcloud:::.pkgenv[["apiClientInstance"]]
+if (is.null(apiClientInstance)) exit_file("not logged in")
+
+# ----------------------------------------------------------------
+info <- tiledbcloud::array_info(namespace="TileDB-Inc", arrayname="quickstart_dense")
+
+expect_equal(info$namespace, "TileDB-Inc")
+expect_equal(info$name, "quickstart_dense")
+expect_equal(info$tiledb_uri, "tiledb://TileDB-Inc/quickstart_dense")

--- a/inst/tinytest/test_array_info.R
+++ b/inst/tinytest/test_array_info.R
@@ -12,15 +12,10 @@ library(tiledbcloud)
 library(tinytest)
 
 # ----------------------------------------------------------------
-# This .pkgenv is managed opaquely by the manual-layer API.
-# However, it's nice to consult it as a logged-in check, and
-# for consistency with other test files in this package.
-apiClientInstance <- tiledbcloud:::.pkgenv[["apiClientInstance"]]
-if (is.null(apiClientInstance)) exit_file("not logged in")
+if (!tiledbcloud:::.logged_in()) exit_file("not logged in")
 
 # ----------------------------------------------------------------
 info <- tiledbcloud::array_info(namespace="TileDB-Inc", arrayname="quickstart_dense")
-
 expect_equal(info$namespace, "TileDB-Inc")
 expect_equal(info$name, "quickstart_dense")
 expect_equal(info$tiledb_uri, "tiledb://TileDB-Inc/quickstart_dense")

--- a/inst/tinytest/test_show_profile.R
+++ b/inst/tinytest/test_show_profile.R
@@ -1,0 +1,35 @@
+if ((unitTestToken <- Sys.getenv("TILEDB_REST_UNIT_TEST_TOKEN")) != "") {
+    Sys.setenv("TILEDB_REST_TOKEN"=unitTestToken)
+} else {
+    if (!file.exists("~/.tiledb/cloud.json")) exit_file("No authentication")
+}
+
+if ((namespaceToCharge <- Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE")) == "") {
+    exit_file("No TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE in environment")
+}
+
+library(tiledbcloud)
+library(tinytest)
+
+# ----------------------------------------------------------------
+# This .pkgenv is managed opaquely by the manual-layer API.
+# However, it's nice to consult it as a logged-in check, and
+# for consistency with other test files in this package.
+apiClientInstance <- tiledbcloud:::.pkgenv[["apiClientInstance"]]
+if (is.null(apiClientInstance)) exit_file("not logged in")
+
+# ----------------------------------------------------------------
+# The result of show_profile() will vary depending on which user runs this
+# test.  But we can check essential things, such as whether some fields are
+# present and non-empty.
+
+p <- tiledbcloud::user_profile()
+
+expect_equal(length(p$id), 1)
+expect_true(nchar(p$id[[1]]) > 0)
+
+expect_equal(length(p$name), 1)
+expect_true(nchar(p$name[[1]]) > 0)
+
+expect_equal(length(p$email), 1)
+expect_true(nchar(p$email[[1]]) > 0)

--- a/inst/tinytest/test_show_profile.R
+++ b/inst/tinytest/test_show_profile.R
@@ -12,11 +12,7 @@ library(tiledbcloud)
 library(tinytest)
 
 # ----------------------------------------------------------------
-# This .pkgenv is managed opaquely by the manual-layer API.
-# However, it's nice to consult it as a logged-in check, and
-# for consistency with other test files in this package.
-apiClientInstance <- tiledbcloud:::.pkgenv[["apiClientInstance"]]
-if (is.null(apiClientInstance)) exit_file("not logged in")
+if (!tiledbcloud:::.logged_in()) exit_file("not logged in")
 
 # ----------------------------------------------------------------
 # The result of show_profile() will vary depending on which user runs this

--- a/inst/tinytest/test_sql.R
+++ b/inst/tinytest/test_sql.R
@@ -11,8 +11,6 @@ library(tinytest)
 
 apiClientInstance <- tiledbcloud:::.pkgenv[["apiClientInstance"]]
 userApiInstance <- tiledbcloud:::.pkgenv[["userApiInstance"]]
-#res <- userApiInstance$GetUser()
-#print(str(res))
 
 sql <- SqlApi$new(apiClientInstance)
 expect_true(is(sql, "SqlApi"))

--- a/inst/tinytest/test_udf_execution.R
+++ b/inst/tinytest/test_udf_execution.R
@@ -94,11 +94,21 @@ expect_equal(result, 2515456)
 # ----------------------------------------------------------------
 # TODO:
 # palmer
+myfunc <- function(df) {
+  vec1 <- as.vector(df$bill_length_mm)
+  vec2 <- as.vector(df$body_mass_g)
+  lm.fit(cbind(1, vec2), vec1)$coefficients
+}
+result <- tiledbcloud::execute_array_udf(
+    namespace=namespaceToCharge,
+    array="tiledb://johnkerl/palmer_penguins2",
+    udf=myfunc,
+    selectedRanges=list(cbind("A", "Z"), cbind(2007,2009)),
+    attrs=list("bill_length_mm", "body_mass_g")
+)
+expect_equal(result, c(27.15072200, vec2=0.00400329))
 
-# cloud-delegate
-
-# show_profile .. ?
-
+# ================================================================
 # array info
 # list-owned-arrays
 # list-public-arrays

--- a/inst/tinytest/test_udf_execution.R
+++ b/inst/tinytest/test_udf_execution.R
@@ -103,8 +103,3 @@ result <- tiledbcloud::execute_array_udf(
     attrs=list("bill_length_mm", "body_mass_g")
 )
 expect_equal(result, c(27.15072200, vec2=0.00400329))
-
-# ================================================================
-# register generic
-# execute registered generic
-# deregister generic

--- a/inst/tinytest/test_udf_execution.R
+++ b/inst/tinytest/test_udf_execution.R
@@ -1,0 +1,109 @@
+if ((unitTestToken <- Sys.getenv("TILEDB_REST_UNIT_TEST_TOKEN")) != "") {
+    Sys.setenv("TILEDB_REST_TOKEN"=unitTestToken)
+} else {
+    if (!file.exists("~/.tiledb/cloud.json")) exit_file("No authentication")
+}
+
+if ((namespaceToCharge <- Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE")) == "") {
+    exit_file("No TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE in environment")
+}
+
+library(tiledbcloud)
+library(tinytest)
+
+# ----------------------------------------------------------------
+# This .pkgenv is managed opaquely by the manual-layer API.
+# However, it's nice to consult it as a logged-in check, and
+# for consistency with other test files in this package.
+apiClientInstance <- tiledbcloud:::.pkgenv[["apiClientInstance"]]
+if (is.null(apiClientInstance)) exit_file("not logged in")
+
+# ----------------------------------------------------------------
+# Generic UDF, no args
+myfunc <- function(x=50:54, y=70:74) { x + y }
+result <- tiledbcloud::execute_generic_udf(namespace=namespaceToCharge, udf=myfunc)
+expect_equal(result, c(120, 122, 124, 126, 128))
+
+# ----------------------------------------------------------------
+# Generic UDF, with args
+myfunc <- function(x, y) { x + y }
+myargs <- list(100:104, 200:204)
+result <- tiledbcloud::execute_generic_udf(namespace=namespaceToCharge, udf=myfunc, args=myargs)
+expect_equal(result, c(300, 302, 304, 306, 308))
+
+# ----------------------------------------------------------------
+# Array UDF, no args, dense
+myfunc <- function(df) {
+  vec <- as.vector(df[["a"]])
+  list(min=min(vec), med=median(vec), max=max(vec))
+}
+result <- tiledbcloud::execute_array_udf(
+  namespace=namespaceToCharge,
+  array="TileDB-Inc/quickstart_dense",
+  udf=myfunc,
+  selectedRanges=list(cbind(1,2), cbind(1,2)),
+  attrs=c("a")
+)
+expect_equal(result, list(min=1, med=3.5, max=6))
+
+# ----------------------------------------------------------------
+# Array UDF, sparse, no args
+myfunc <- function(df) {
+  vec <- as.vector(df[["a"]])
+  list(min=min(vec), med=median(vec), max=max(vec))
+}
+result <- tiledbcloud::execute_array_udf(
+  namespace=namespaceToCharge,
+  array="TileDB-Inc/quickstart_sparse",
+  udf=myfunc,
+  selectedRanges=list(cbind(1,4), cbind(1,4)),
+  attrs=c("a")
+)
+expect_equal(result, list(min=1, med=2, max=3))
+
+# ----------------------------------------------------------------
+# Array UDF, dense, with args
+array_name <- "TileDB-Inc/quickstart_dense"
+myfunc <- function(df, exponent) {
+  vec <- as.vector(df[["a"]])
+  sum(vec) ** exponent
+}
+selectedRanges <- list(cbind(1,4), cbind(1,4))
+attrs <- c("a")
+
+result <- tiledbcloud::execute_array_udf(
+  namespace=namespaceToCharge,
+  array=array_name,
+  udf=myfunc,
+  selectedRanges=selectedRanges,
+  attrs=attrs,
+  args=list(exponent=2)
+)
+expect_equal(result, 18496)
+
+result <- tiledbcloud::execute_array_udf(
+  namespace=namespaceToCharge,
+  array=array_name,
+  udf=myfunc,
+  selectedRanges=selectedRanges,
+  attrs=attrs,
+  args=list(exponent=3)
+)
+expect_equal(result, 2515456)
+
+# ----------------------------------------------------------------
+# TODO:
+# palmer
+
+# cloud-delegate
+
+# show_profile .. ?
+
+# array info
+# list-owned-arrays
+# list-public-arrays
+# list-shared-arrays
+
+# register generic
+# execute registered generic
+# deregister generic

--- a/inst/tinytest/test_udf_execution.R
+++ b/inst/tinytest/test_udf_execution.R
@@ -12,11 +12,7 @@ library(tiledbcloud)
 library(tinytest)
 
 # ----------------------------------------------------------------
-# This .pkgenv is managed opaquely by the manual-layer API.
-# However, it's nice to consult it as a logged-in check, and
-# for consistency with other test files in this package.
-apiClientInstance <- tiledbcloud:::.pkgenv[["apiClientInstance"]]
-if (is.null(apiClientInstance)) exit_file("not logged in")
+if (!tiledbcloud:::.logged_in()) exit_file("not logged in")
 
 # ----------------------------------------------------------------
 # Generic UDF, no args

--- a/inst/tinytest/test_udf_execution.R
+++ b/inst/tinytest/test_udf_execution.R
@@ -88,18 +88,17 @@ result <- tiledbcloud::execute_array_udf(
 expect_equal(result, 2515456)
 
 # ----------------------------------------------------------------
-# TODO:
-# palmer
-myfunc <- function(df) {
-  vec1 <- as.vector(df$bill_length_mm)
-  vec2 <- as.vector(df$body_mass_g)
-  lm.fit(cbind(1, vec2), vec1)$coefficients
-}
-result <- tiledbcloud::execute_array_udf(
-    namespace=namespaceToCharge,
-    array="tiledb://johnkerl/palmer_penguins2",
-    udf=myfunc,
-    selectedRanges=list(cbind("A", "Z"), cbind(2007,2009)),
-    attrs=list("bill_length_mm", "body_mass_g")
-)
-expect_equal(result, c(27.15072200, vec2=0.00400329))
+# TODO: put this into TileDB-Inc namespace
+# myfunc <- function(df) {
+#   vec1 <- as.vector(df$bill_length_mm)
+#   vec2 <- as.vector(df$body_mass_g)
+#   lm.fit(cbind(1, vec2), vec1)$coefficients
+# }
+# result <- tiledbcloud::execute_array_udf(
+#     namespace=namespaceToCharge,
+#     array="tiledb://johnkerl/palmer_penguins2",
+#     udf=myfunc,
+#     selectedRanges=list(cbind("A", "Z"), cbind(2007,2009)),
+#     attrs=list("bill_length_mm", "body_mass_g")
+# )
+# expect_equal(result, c(27.15072200, vec2=0.00400329))

--- a/inst/tinytest/test_udf_execution.R
+++ b/inst/tinytest/test_udf_execution.R
@@ -109,11 +109,6 @@ result <- tiledbcloud::execute_array_udf(
 expect_equal(result, c(27.15072200, vec2=0.00400329))
 
 # ================================================================
-# array info
-# list-owned-arrays
-# list-public-arrays
-# list-shared-arrays
-
 # register generic
 # execute registered generic
 # deregister generic

--- a/inst/tinytest/test_udf_registration_generic.R
+++ b/inst/tinytest/test_udf_registration_generic.R
@@ -1,0 +1,51 @@
+if ((unitTestToken <- Sys.getenv("TILEDB_REST_UNIT_TEST_TOKEN")) != "") {
+    Sys.setenv("TILEDB_REST_TOKEN"=unitTestToken)
+} else {
+    if (!file.exists("~/.tiledb/cloud.json")) exit_file("No authentication")
+}
+
+if ((namespaceToCharge <- Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE")) == "") {
+    exit_file("No TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE in environment")
+}
+
+library(tiledbcloud)
+library(tinytest)
+
+# ----------------------------------------------------------------
+if (!tiledbcloud:::.logged_in()) exit_file("not logged in")
+
+# ----------------------------------------------------------------
+make_udf_name <- function(base) {
+  paste(base, floor(as.numeric(Sys.time())), floor(runif(1, min = 100000, max = 999999)), sep="_")
+}
+
+# ================================================================
+udfname <- make_udf_name('udf-registration-test-generic')
+myfunc <- function(vec, exponent) {
+  sum(vec) ** exponent
+}
+
+# ----------------------------------------------------------------
+tiledbcloud::register_udf(namespace=namespaceToCharge, name=udfname, type='generic', func=myfunc)
+info <- tiledbcloud::get_udf_info(namespace=namespaceToCharge, name=udfname)
+expect_equal(info$name, udfname)
+
+# ----------------------------------------------------------------
+registered_udf_name=paste(namespaceToCharge, udfname, sep='/')
+
+result <- tiledbcloud::execute_generic_udf(
+  namespace=namespaceToCharge,
+  registered_udf_name=registered_udf_name,
+  args=list(vec=1:10, exponent=2)
+)
+expect_equal(result, 3025)
+
+result <- tiledbcloud::execute_generic_udf(
+  namespace=namespaceToCharge,
+  registered_udf_name=registered_udf_name,
+  args=list(vec=1:10, exponent=3)
+)
+expect_equal(result, 166375)
+
+# ----------------------------------------------------------------
+tiledbcloud::deregister_udf(namespace=namespaceToCharge, name=udfname)

--- a/inst/tinytest/test_udf_registration_multi_array.R
+++ b/inst/tinytest/test_udf_registration_multi_array.R
@@ -1,0 +1,78 @@
+if ((unitTestToken <- Sys.getenv("TILEDB_REST_UNIT_TEST_TOKEN")) != "") {
+    Sys.setenv("TILEDB_REST_TOKEN"=unitTestToken)
+} else {
+    if (!file.exists("~/.tiledb/cloud.json")) exit_file("No authentication")
+}
+
+if ((namespaceToCharge <- Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE")) == "") {
+    exit_file("No TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE in environment")
+}
+
+library(tiledbcloud)
+library(tinytest)
+
+# ----------------------------------------------------------------
+if (!tiledbcloud:::.logged_in()) exit_file("not logged in")
+
+# ----------------------------------------------------------------
+make_udf_name <- function(base) {
+  paste(base, floor(as.numeric(Sys.time())), floor(runif(1, min = 100000, max = 999999)), sep="_")
+}
+
+# ================================================================
+udfname <- make_udf_name('udf-registration-test-multi-array')
+
+myfunc <- function(df1, df2, attrname) {
+  vec1 <- as.vector(df1[[attrname]])
+  vec2 <- as.vector(df2[[attrname]])
+  list(
+    len=length(vec1) + length(vec2),
+    min=min(vec1) + min(vec2),
+    med=median(vec1) + median(vec2),
+    max=max(vec1) + max(vec2)
+  )
+}
+
+tiledbcloud::register_udf(namespace=namespaceToCharge, name=udfname, type='multi_array', func=myfunc)
+
+info <- tiledbcloud::get_udf_info(namespace=namespaceToCharge, name=udfname)
+expect_equal(info$name, udfname)
+
+tiledbcloud::update_udf_info(namespace=namespaceToCharge, name=udfname, type='multi_array', func=myfunc, tags=list("testing", "udf", "upload"), readme='Here is the README text', version='2.0')
+
+info <- tiledbcloud::get_udf_info(namespace=namespaceToCharge, name=udfname)
+expect_equal(info$name, udfname)
+expect_equal(info$readme, 'Here is the README text')
+# Written as list(...), read back as c(...) -- this is expected.
+expect_equal(info$tags, c("testing", "udf", "upload"))
+
+# ----------------------------------------------------------------
+details1 <- tiledbcloud::UDFArrayDetails$new(
+  uri="tiledb://TileDB-Inc/quickstart_dense",
+  ranges=QueryRanges$new(
+    layout=Layout$new('row-major'),
+    ranges=list(cbind(1,4),cbind(1,4))
+  ),
+  buffers=list("a")
+)
+
+details2 <- tiledbcloud::UDFArrayDetails$new(
+  uri="tiledb://TileDB-Inc/quickstart_sparse",
+  ranges=QueryRanges$new(
+    layout=Layout$new('row-major'),
+    ranges=list(cbind(1,2),cbind(1,4))
+  ),
+  buffers=list("a")
+)
+
+registered_udf_name=paste(namespaceToCharge, udfname, sep='/')
+result <- tiledbcloud::execute_multi_array_udf(
+  namespace=namespaceToCharge,
+  array_list=list(details1, details2),
+  registered_udf_name=registered_udf_name,
+  args=list(attrname="a")
+)
+expect_equal(result, list(len=19, min=2, med=10.5, max=19))
+
+# ----------------------------------------------------------------
+tiledbcloud::deregister_udf(namespace=namespaceToCharge, name=udfname)

--- a/inst/tinytest/test_udf_registration_single_array.R
+++ b/inst/tinytest/test_udf_registration_single_array.R
@@ -1,0 +1,62 @@
+if ((unitTestToken <- Sys.getenv("TILEDB_REST_UNIT_TEST_TOKEN")) != "") {
+    Sys.setenv("TILEDB_REST_TOKEN"=unitTestToken)
+} else {
+    if (!file.exists("~/.tiledb/cloud.json")) exit_file("No authentication")
+}
+
+if ((namespaceToCharge <- Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE")) == "") {
+    exit_file("No TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE in environment")
+}
+
+library(tiledbcloud)
+library(tinytest)
+
+# ----------------------------------------------------------------
+if (!tiledbcloud:::.logged_in()) exit_file("not logged in")
+
+# ----------------------------------------------------------------
+make_udf_name <- function(base) {
+  paste(base, floor(as.numeric(Sys.time())), floor(runif(1, min = 100000, max = 999999)), sep="_")
+}
+
+# ================================================================
+udfname <- make_udf_name('udf-registration-test-single-array')
+
+myfunc <- function(df, attrname, exponent) {
+  vec <- as.vector(df[[attrname]])
+  sum(vec) ** exponent
+}
+
+tiledbcloud::register_udf(namespace=namespaceToCharge, name=udfname, type='single_array', func=myfunc)
+
+Sys.sleep(2)
+
+info <- tiledbcloud::get_udf_info(namespace=namespaceToCharge, name=udfname)
+expect_equal(info$name, udfname)
+
+Sys.sleep(2)
+
+tiledbcloud::update_udf_info(namespace=namespaceToCharge, name=udfname, type='single_array', func=myfunc, tags=list("testing", "udf", "upload"), readme='Here is the README text', version='2.0')
+
+Sys.sleep(2)
+
+info <- tiledbcloud::get_udf_info(namespace=namespaceToCharge, name=udfname)
+expect_equal(info$name, udfname)
+expect_equal(info$readme, 'Here is the README text')
+# Written as list(...), read back as c(...) -- this is expected.
+expect_equal(info$tags, c("testing", "udf", "upload"))
+
+# ----------------------------------------------------------------
+registered_udf_name=paste(namespaceToCharge, udfname, sep='/')
+result <- tiledbcloud::execute_array_udf(
+  namespace=namespaceToCharge,
+  array="TileDB-Inc/quickstart_dense",
+  registered_udf_name=registered_udf_name,
+  args=list(attrname="a", exponent=2),
+  selectedRanges=list(cbind(1,2), cbind(1,2)),
+  attrs=c("a")
+)
+expect_equal(result, 196)
+
+# ----------------------------------------------------------------
+tiledbcloud::deregister_udf(namespace=namespaceToCharge, name=udfname)

--- a/vignettes/Testing.md
+++ b/vignettes/Testing.md
@@ -20,5 +20,6 @@ which we don't want to push on all users who build the package locally.
 To opt in:
 
 * Have either environment variable `TILEDB_REST_TOKEN`, or the pair `TILEDB_REST_USERNAME` and `TILEDB_REST_PASSWORD` -- or all three if you like.
+* You will also need environment variable `TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE` for the (very minor) cloud costs associated with invoking UDFs.
 * Optionally, `TILEDB_REST_HOST` if your cloud installation is local, and/or for TileDB employees pointing at our staging environment.
 * In R: `tinytest::test_all(".")`


### PR DESCRIPTION
Heretofore (accumulating over the last couple months), this code was manually invoked from a temp repo outside of this one.

This PR moves that code into place inside `TileDB-Cloud-R`.

Validation:

```
> tinytest::test_all(".")
test_array_info.R.............    3 tests OK 0.5s
test_array.R..................    7 tests OK 0.4s
test_get_session.R............    5 tests OK 0.1s
test_get_user.R...............    3 tests OK 0.2s
test_show_profile.R...........    6 tests OK 0.1s
test_sql.R....................    2 tests OK 4ms
test_udf_execution.R..........    7 tests OK 18.2s
test_udf_registration_generic.R    3 tests OK 14.5s
test_udf_registration_multi_array.R    5 tests OK 32.1s
test_udf_registration_single_array.R    5 tests OK 35.0s
All ok, 46 results (1m 41.2s)
```