### PR TITLE
Support result_format in generic UDFs

### DIFF
--- a/R/manual_layer_udf.R
+++ b/R/manual_layer_udf.R
@@ -52,9 +52,11 @@ execute_generic_udf <- function(namespace, udf=NULL, registered_udf_name=NULL, a
   if (!is.null(args)) {
     generic_udf$argument <- jsonlite::toJSON(as.integer(serialize(args, NULL)))
   }
-  if (!is.null(result_format)) {
-    generic_udf$result_format <- ResultFormat$new(result_format)
-  }
+  stopifnot (!is.null(result_format))
+  # Here we rely on ResultFormat$new to match against the acceptable values for
+  # result format, which in turn are automatically generated from the
+  # TileDB-Cloud OpenAPI spec.
+  generic_udf$result_format <- ResultFormat$new(result_format)
 
   resultObject <- udfApiInstance$SubmitGenericUDF(namespace, generic_udf)
 
@@ -150,9 +152,11 @@ execute_array_udf <- function(array, namespace=NULL, udf=NULL, registered_udf_na
     multi_array_udf$argument <- jsonlite::toJSON(as.integer(serialize(args, NULL)))
   }
 
-  if (!is.null(result_format)) {
-    multi_array_udf$result_format <- ResultFormat$new(result_format)
-  }
+  stopifnot (!is.null(result_format))
+  # Here we rely on ResultFormat$new to match against the acceptable values for
+  # result format, which in turn are automatically generated from the
+  # TileDB-Cloud OpenAPI spec.
+  multi_array_udf$result_format <- ResultFormat$new(result_format)
 
   # Attrs can be optionally specified by the client. If they are not, the
   # server-side code will load all attributes.
@@ -239,9 +243,11 @@ execute_multi_array_udf <- function(namespace, array_list, udf=NULL, registered_
     multi_array_udf$argument <- jsonlite::toJSON(as.integer(serialize(args, NULL)))
   }
 
-  if (!is.null(result_format)) {
-    multi_array_udf$result_format <- ResultFormat$new(result_format)
-  }
+  stopifnot (!is.null(result_format))
+  # Here we rely on ResultFormat$new to match against the acceptable values for
+  # result format, which in turn are automatically generated from the
+  # TileDB-Cloud OpenAPI spec.
+  multi_array_udf$result_format <- ResultFormat$new(result_format)
 
   # TODO: type-check the array_list parameter to be sure it's list of UDFArrayDetails
   multi_array_udf$arrays <- array_list

--- a/inst/tinytest/test_c_udf_execution.R
+++ b/inst/tinytest/test_c_udf_execution.R
@@ -28,6 +28,20 @@ result <- tiledbcloud::execute_generic_udf(namespace=namespaceToCharge, udf=myfu
 expect_equal(result, c(300, 302, 304, 306, 308))
 
 # ----------------------------------------------------------------
+# Generic UDF, with result_format
+
+myfunc <- function(x, y) { x + y }
+myargs <- list(100:104, 200:204)
+result <- tiledbcloud::execute_generic_udf(namespace=namespaceToCharge, udf=myfunc, args=myargs, result_format='json')
+expect_equal(result, c(300, 302, 304, 306, 308))
+
+myfunc <- function(x, y) { x + y }
+myargs <- list(100:104, 200:204)
+result <- tiledbcloud::execute_generic_udf(namespace=namespaceToCharge, udf=myfunc, args=myargs, result_format='arrow')
+# Arrow result is of type dataframe, so we pull out the 'result' slot
+expect_equal(result$result, c(300, 302, 304, 306, 308))
+
+# ----------------------------------------------------------------
 # Array UDF, no args, dense
 myfunc <- function(df) {
   vec <- as.vector(df[["a"]])
@@ -86,6 +100,29 @@ result <- tiledbcloud::execute_array_udf(
   args=list(exponent=3)
 )
 expect_equal(result, 2515456)
+
+result <- tiledbcloud::execute_array_udf(
+  namespace=namespaceToCharge,
+  array=array_name,
+  udf=myfunc,
+  selectedRanges=selectedRanges,
+  attrs=attrs,
+  args=list(exponent=3),
+  result_format='json'
+)
+expect_equal(result, 2515456)
+
+result <- tiledbcloud::execute_array_udf(
+  namespace=namespaceToCharge,
+  array=array_name,
+  udf=myfunc,
+  selectedRanges=selectedRanges,
+  attrs=attrs,
+  args=list(exponent=3),
+  result_format='arrow'
+)
+# Arrow result is of type dataframe, so we pull out the 'result' slot
+expect_equal(result$result, 2515456)
 
 # ----------------------------------------------------------------
 # TODO: put this into TileDB-Inc namespace

--- a/man/execute_array_udf.Rd
+++ b/man/execute_array_udf.Rd
@@ -34,7 +34,9 @@ Arguments are specified separately via \code{args}.  One of \code{udf} and
 \item{selectedRanges}{List of two-column matrices, one matrix per dimension,
 each matrix being a start-end pair: e.g. \code{list(cbind(1,10),cbind(1,20))}.}
 
-\item{attrs}{}
+\item{attrs}{Optional list of attributes (default: all) for the server-side
+code to select for UDF execution. Specifying only what your UDF needs is
+useful for memory-usage control.}
 
 \item{layout}{One of \code{row-major}, \code{col-major}, \code{global-order}, or
 \code{unordered},}

--- a/man/execute_generic_udf.Rd
+++ b/man/execute_generic_udf.Rd
@@ -8,7 +8,8 @@ execute_generic_udf(
   namespace,
   udf = NULL,
   registered_udf_name = NULL,
-  args = NULL
+  args = NULL,
+  result_format = "native"
 )
 }
 \arguments{
@@ -25,6 +26,11 @@ Arguments are specified separately via \code{args}.  One of \code{udf} and
 no arguments, this can be omitted. If you want to call by
 position, use a list like \code{args=list(123, 456)}. If you want
 to call by name, use a named list like \code{args=list(x=123,y=456)}.}
+
+\item{result_format}{One of \code{native}, \code{json}, or \code{arrow}. These are
+used as wire format for returning results from the server to this library, primarily
+for memory-usage control.  UDF return values handed back to your code from this
+library are converted back to natural R objects.}
 }
 \value{
 The R object which is the return value from the UDF.


### PR DESCRIPTION
This was already parameterized for array UDFs; it was an oversight not to have parameterized it for generic UDFs.

This is extractable out as a bite-sized PR even though it exists in support of task-graph work, including the soon-to-be-posted ability to invoke Python generic/array UDFs, registered in TileDB Cloud, from R.

Example usages are on `inst/tinytest/test_c_udf_execution.R`.

On a PR later today I'll include some vignette notes on limitations here -- mainly, Arrow and JSON can't serialize NumPy types which puts a constraint on UDF return values, e.g. `return int(foo)` rather than just `return foo` when `foo` is the result of a NumPy computation.