### PR TITLE
Remove some unnecessary double-quoting in HTTP/JSON marshaling

### DIFF
--- a/R/result_format.R
+++ b/R/result_format.R
@@ -32,7 +32,21 @@ ResultFormat <- R6::R6Class(
             private$value <- val
         },
         toJSON = function() {
-            jsonlite::toJSON(private$value, auto_unbox = TRUE)
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            #
+            # The name toJSON is a misnomer -- its output is not a string.
+            # The name toJSONString is correct -- its output is a string.
+            # The way this works for HTTP/JSON serdes is a top-level R6 object
+            # (like GenericUDF) gets its toJSONString invoked; that in turn
+            # recursively invokes toJSON on various subattributes.
+            #
+            # This default logic written by OpenAPI results in JSON like
+            # { ..., "result_format": "\"arrow\"", ... }
+            # Here, we make sure that instead the following is generated:
+            # { ..., "result_format": "arrow", ... }
+            #
+            # jsonlite::toJSON(private$value, auto_unbox = TRUE)
+            private$value
         },
         fromJSON = function(ResultFormatJson) {
             private$value <- jsonlite::fromJSON(ResultFormatJson,

--- a/R/udf_language.R
+++ b/R/udf_language.R
@@ -32,7 +32,21 @@ UDFLanguage <- R6::R6Class(
             private$value <- val
         },
         toJSON = function() {
-            jsonlite::toJSON(private$value, auto_unbox = TRUE)
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            #
+            # The name toJSON is a misnomer -- its output is not a string.
+            # The name toJSONString is correct -- its output is a string.
+            # The way this works for HTTP/JSON serdes is a top-level R6 object
+            # (like GenericUDF) gets its toJSONString invoked; that in turn
+            # recursively invokes toJSON on various subattributes.
+            #
+            # This default logic written by OpenAPI results in JSON like
+            # { ..., "language": "\"r\"", ... }
+            # Here, we make sure that instead the following is generated:
+            # { ..., "languae": "r", ... }
+            #
+            # jsonlite::toJSON(private$value, auto_unbox = TRUE)
+            private$value
         },
         fromJSON = function(UDFLanguageJson) {
             private$value <- jsonlite::fromJSON(UDFLanguageJson,


### PR DESCRIPTION
The REST server already contains a server-side re-write to map `"language":"\"r\""` but it doesn't yet have a server-side re-write for `"result_format":"\"arrow\""` etc. I'm about to need that on other PRs today, so instead of adding another server-side workaround, I'm fixing the misformatting at the client as it should be.

Note that existing `inst/tinytest` covers unit-testing of all this logic with live calls to TileDB Cloud.