### PR TITLE
Add an HTTP-debug option to facilitate development

### DIFF
--- a/R/api_client.R
+++ b/R/api_client.R
@@ -105,7 +105,7 @@ ApiClient  <- R6::R6Class(
 
     CallApi = function(url, method, queryParams, headerParams, body, ...){
 
-      if (Sys.getenv("TILEDB_CLOUD_R_HTTP_PRINT") != "") {
+      if (Sys.getenv("TILEDB_CLOUD_R_HTTP_DEBUG") != "") {
         cat("================================================================ REQUEST\n")
         cat("METHOD:", method, "\n")
         cat("QUERY_PARAMS:\n")
@@ -141,7 +141,7 @@ ApiClient  <- R6::R6Class(
         }  
       }
 
-      if (Sys.getenv("TILEDB_CLOUD_R_HTTP_PRINT") != "") {
+      if (Sys.getenv("TILEDB_CLOUD_R_HTTP_DEBUG") != "") {
         cat("================================================================ RESPONSE\n")
         cat("STATUS_CODE:", statusCode, "\n")
         cat("BODY:\n")

--- a/R/api_client.R
+++ b/R/api_client.R
@@ -105,6 +105,22 @@ ApiClient  <- R6::R6Class(
 
     CallApi = function(url, method, queryParams, headerParams, body, ...){
 
+      if (Sys.getenv("TILEDB_CLOUD_R_HTTP_PRINT") != "") {
+        cat("================================================================ REQUEST\n")
+        cat("METHOD:", method, "\n")
+        cat("QUERY_PARAMS:\n")
+        str(queryParams, width=1000, nchar.max=10000)
+        cat("HEADER_PARAMS:\n")
+        str(headerParams, width=1000, nchar.max=10000)
+        cat("BODY:\n")
+        if (is.null(body)) {
+          cat("(NULL)\n")
+        } else {
+          cat(body, "\n")
+        }
+        cat("================================================================\n")
+      }
+
       resp <- self$Execute(url, method, queryParams, headerParams, body, ...)
       statusCode <- httr::status_code(resp)
 
@@ -123,6 +139,14 @@ ApiClient  <- R6::R6Class(
             break;
           }
         }  
+      }
+
+      if (Sys.getenv("TILEDB_CLOUD_R_HTTP_PRINT") != "") {
+        cat("================================================================ RESPONSE\n")
+        cat("STATUS_CODE:", statusCode, "\n")
+        cat("BODY:\n")
+        str(resp, width=1000, nchar.max=10000)
+        cat("================================================================\n")
       }
 
       resp

--- a/vignettes/Testing.Rmd
+++ b/vignettes/Testing.Rmd
@@ -21,3 +21,7 @@ To opt in:
 * You will also need environment variable `TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE` for the (very minor) cloud costs associated with invoking UDFs.
 * Optionally, `TILEDB_REST_HOST` if your cloud installation is local, and/or for TileDB employees pointing at our staging environment.
 * In R: `tinytest::test_all(".")`
+
+Some debug information:
+
+* `export TILEDB_CLOUD_R_HTTP_PRINT=true` will result in helpful printouts to the screen of HTTP requests and responses.

--- a/vignettes/Testing.Rmd
+++ b/vignettes/Testing.Rmd
@@ -24,4 +24,4 @@ To opt in:
 
 Some debug information:
 
-* `export TILEDB_CLOUD_R_HTTP_PRINT=true` will result in helpful printouts to the screen of HTTP requests and responses.
+* `export TILEDB_CLOUD_R_HTTP_DEBUG=true` will result in helpful printouts to the screen of HTTP requests and responses.


### PR DESCRIPTION
Routinely for the last couple months I've temp-added prints like these during development, then removed them before putting up PRs.

Here I simply persist and expose that logic in order to make it easier and more accessible for everyone.

Example use:

```
$ export TILEDB_CLOUD_R_HTTP_DEBUG=true

$ R

> library(tiledbcloud)

> library(tiledb)

> namespace <- Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE", unset="johnkerl")

> myfunc <- function(df) {
+   vec <- as.vector(df[["a"]])
+   list(min=min(vec), med=median(vec), max=max(vec))
+ }

> result <- tiledbcloud::execute_array_udf(
+   namespace=namespace, # namespace to charge
+   array="TileDB-Inc/quickstart_dense",
+   udf=myfunc,
+   selectedRanges=list(cbind(1,2), cbind(1,2)),
+   attrs=c("a")
+ )

================================================================ REQUEST
METHOD: POST
QUERY_PARAMS:
 list()
HEADER_PARAMS:
 Named chr [1:3] "johnkerl-tiledb" "eyJ[snip]wsZWRiOnMkVGJoN2UxakIjJUhnc2VOIVBZ"
 - attr(*, "names")= chr [1:3] "X-Payer" "X-TILEDB-REST-API-KEY" "Authorization"
BODY:
{"language":
        "\"r\""
        ,"exec":
          "[88,10,0[snip]5,0,0,0,254,0,0,0,254,0,0,0,254]"
                ,"result_format":
        "\"native\""
        ,"ranges":
        {"ranges":"[[1,2],[1,2]]"}
        ,"buffers":
           ["a"]
        }
================================================================
================================================================ RESPONSE
STATUS_CODE: 200
BODY:
List of 10
 $ url        : chr "https://us-east-1.aws.api.tiledb.com/v1/arrays/TileDB-Inc/quickstart_dense/udf/submit"
 $ status_code: int 200
 $ headers    :List of 13
  ..$ date                              : chr "Thu, 03 Feb 2022 16:54:53 GMT"
  ..$ content-type                      : chr "application/octet-stream"
  ..$ transfer-encoding                 : chr "chunked"
  ..$ connection                        : chr "keep-alive"
  ..$ content-encoding                  : chr "deflate"
  ..$ vary                              : chr "Origin"
  ..$ x-build-id                        : chr "4b1a8586e64f868dac49fab6b9c8122dd28b743d"
  ..$ x-content-type-options            : chr "nosniff"
  ..$ x-rate-limit-duration             : chr "1"
  ..$ x-rate-limit-limit                : chr "50.00"
  ..$ x-rate-limit-request-forwarded-for: chr "108.48.174.113"
  ..$ x-rate-limit-request-remote-addr  : chr "10.40.171.33:45158"
  ..$ x-tiledb-cloud-task-id            : chr "b1f74cb4-4c97-4187-a0dc-21cea0d667fd"
  ..- attr(*, "class")= chr [1:2] "insensitive" "list"
 $ all_headers:List of 2
  ..$ :List of 3
  .. ..$ status : int 307
  .. ..$ version: chr "HTTP/2"
  .. ..$ headers:List of 14
  .. .. ..$ date                       : chr "Thu, 03 Feb 2022 16:54:50 GMT"
  .. .. ..$ content-length             : chr "0"
  .. .. ..$ location                   : chr "https://us-east-1.aws.api.tiledb.com/v1/arrays/TileDB-Inc/quickstart_dense/udf/submit"
  .. .. ..$ access-control-allow-origin: chr "*"
  [snip]
  ..$ :List of 3
  .. ..$ status : int 200
  .. ..$ version: chr "HTTP/1.1"
  .. ..$ headers:List of 13
  .. .. ..$ date                              : chr "Thu, 03 Feb 2022 16:54:53 GMT"
  .. .. ..$ content-type                      : chr "application/octet-stream"
  .. .. ..$ transfer-encoding                 : chr "chunked"
  .. .. ..$ connection                        : chr "keep-alive"
  .. .. ..$ content-encoding                  : chr "deflate"
  [snip]
================================================================

> print(result)
$min
[1] 1

$med
[1] 3.5

$max
[1] 6
```