### PR TITLE
Improve error wording for enum-matching

### DIFF
--- a/R/activity_event_type.R
+++ b/R/activity_event_type.R
@@ -22,12 +22,9 @@ ActivityEventType <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_ActivityEventType()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for activity_event_type: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("ActivityEventType", val, .parse_ActivityEventType())
 
             private$value <- val
         },

--- a/R/activity_event_type.R
+++ b/R/activity_event_type.R
@@ -24,11 +24,11 @@ ActivityEventType <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_ActivityEventType()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for activity_event_type: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/array_actions.R
+++ b/R/array_actions.R
@@ -24,11 +24,11 @@ ArrayActions <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_ArrayActions()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for array_actions: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/array_actions.R
+++ b/R/array_actions.R
@@ -22,12 +22,9 @@ ArrayActions <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_ArrayActions()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for array_actions: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("ArrayActions", val, .parse_ArrayActions())
 
             private$value <- val
         },

--- a/R/array_task_status.R
+++ b/R/array_task_status.R
@@ -24,11 +24,11 @@ ArrayTaskStatus <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_ArrayTaskStatus()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for array_task_status: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/array_task_status.R
+++ b/R/array_task_status.R
@@ -22,12 +22,9 @@ ArrayTaskStatus <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_ArrayTaskStatus()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for array_task_status: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("ArrayTaskStatus", val, .parse_ArrayTaskStatus())
 
             private$value <- val
         },

--- a/R/array_task_type.R
+++ b/R/array_task_type.R
@@ -24,11 +24,11 @@ ArrayTaskType <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_ArrayTaskType()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for array_task_type: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/array_task_type.R
+++ b/R/array_task_type.R
@@ -22,12 +22,9 @@ ArrayTaskType <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_ArrayTaskType()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for array_task_type: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("ArrayTaskType", val, .parse_ArrayTaskType())
 
             private$value <- val
         },

--- a/R/array_type.R
+++ b/R/array_type.R
@@ -22,12 +22,9 @@ ArrayType <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_ArrayType()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for array_type: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("ArrayType", val, .parse_ArrayType())
 
             private$value <- val
         },

--- a/R/array_type.R
+++ b/R/array_type.R
@@ -24,11 +24,11 @@ ArrayType <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_ArrayType()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for array_type: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/datatype.R
+++ b/R/datatype.R
@@ -24,11 +24,11 @@ Datatype <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_Datatype()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for datatype: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/datatype.R
+++ b/R/datatype.R
@@ -22,12 +22,9 @@ Datatype <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_Datatype()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for datatype: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("Datatype", val, .parse_Datatype())
 
             private$value <- val
         },

--- a/R/file_property_name.R
+++ b/R/file_property_name.R
@@ -22,12 +22,9 @@ FilePropertyName <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_FilePropertyName()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for file_property_name: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("FilePropertyName", val, .parse_FilePropertyName())
 
             private$value <- val
         },

--- a/R/file_property_name.R
+++ b/R/file_property_name.R
@@ -24,11 +24,11 @@ FilePropertyName <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_FilePropertyName()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for file_property_name: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/file_type.R
+++ b/R/file_type.R
@@ -24,11 +24,11 @@ FileType <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_FileType()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for file_type: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/file_type.R
+++ b/R/file_type.R
@@ -22,12 +22,9 @@ FileType <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_FileType()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for file_type: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("FileType", val, .parse_FileType())
 
             private$value <- val
         },

--- a/R/filter_option.R
+++ b/R/filter_option.R
@@ -22,12 +22,9 @@ FilterOption <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_FilterOption()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for filter_option: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("FilterOption", val, .parse_FilterOption())
 
             private$value <- val
         },

--- a/R/filter_option.R
+++ b/R/filter_option.R
@@ -24,11 +24,11 @@ FilterOption <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_FilterOption()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for filter_option: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/filter_type.R
+++ b/R/filter_type.R
@@ -22,12 +22,9 @@ FilterType <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_FilterType()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for filter_type: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("FilterType", val, .parse_FilterType())
 
             private$value <- val
         },

--- a/R/filter_type.R
+++ b/R/filter_type.R
@@ -24,11 +24,11 @@ FilterType <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_FilterType()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for filter_type: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/invitation_status.R
+++ b/R/invitation_status.R
@@ -24,11 +24,11 @@ InvitationStatus <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_InvitationStatus()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for invitation_status: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/invitation_status.R
+++ b/R/invitation_status.R
@@ -22,12 +22,9 @@ InvitationStatus <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_InvitationStatus()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for invitation_status: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("InvitationStatus", val, .parse_InvitationStatus())
 
             private$value <- val
         },

--- a/R/invitation_type.R
+++ b/R/invitation_type.R
@@ -22,12 +22,9 @@ InvitationType <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_InvitationType()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for invitation_type: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("InvitationType", val, .parse_InvitationType())
 
             private$value <- val
         },

--- a/R/invitation_type.R
+++ b/R/invitation_type.R
@@ -24,11 +24,11 @@ InvitationType <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_InvitationType()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for invitation_type: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/layout.R
+++ b/R/layout.R
@@ -22,12 +22,9 @@ Layout <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_Layout()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for layout: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("Layout", val, .parse_Layout())
 
             private$value <- val
         },

--- a/R/layout.R
+++ b/R/layout.R
@@ -24,11 +24,11 @@ Layout <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_Layout()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for layout: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/manual_layer_utilities.r
+++ b/R/manual_layer_utilities.r
@@ -7,3 +7,12 @@
   }
   list(namespace=fields[[1]][[1]], name=fields[[1]][[2]])
 }
+
+.check_openapi_enum <- function(name, value, acceptable_values) {
+  if ((length(value) != 1L) || (!value %in% acceptable_values)) {
+    stop("Use one of the valid values for ",
+         name,
+         ": ",
+         paste0(acceptable_values, collapse = ", "))
+  }
+}

--- a/R/namespace_actions.R
+++ b/R/namespace_actions.R
@@ -22,12 +22,9 @@ NamespaceActions <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_NamespaceActions()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for namespace_actions: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("NamespaceActions", val, .parse_NamespaceActions())
 
             private$value <- val
         },

--- a/R/namespace_actions.R
+++ b/R/namespace_actions.R
@@ -24,11 +24,11 @@ NamespaceActions <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_NamespaceActions()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for namespace_actions: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/organization_roles.R
+++ b/R/organization_roles.R
@@ -24,11 +24,11 @@ OrganizationRoles <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_OrganizationRoles()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for organization_roles: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/organization_roles.R
+++ b/R/organization_roles.R
@@ -22,12 +22,9 @@ OrganizationRoles <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_OrganizationRoles()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for organization_roles: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("OrganizationRoles", val, .parse_OrganizationRoles())
 
             private$value <- val
         },

--- a/R/pricing_aggregate_usage.R
+++ b/R/pricing_aggregate_usage.R
@@ -22,12 +22,10 @@ PricingAggregateUsage <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_PricingAggregateUsage()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for pricing_aggregate_usage: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("PricingAggregateUsage", val, .parse_PricingAggregateUsage())
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/pricing_aggregate_usage.R
+++ b/R/pricing_aggregate_usage.R
@@ -24,10 +24,9 @@ PricingAggregateUsage <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_PricingAggregateUsage()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for pricing_aggregate_usage: ",
                     paste0(enumvec, collapse = ", "))
             private$value <- val
         },

--- a/R/pricing_currency.R
+++ b/R/pricing_currency.R
@@ -24,11 +24,11 @@ PricingCurrency <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_PricingCurrency()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for pricing_currency: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/pricing_currency.R
+++ b/R/pricing_currency.R
@@ -22,12 +22,9 @@ PricingCurrency <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_PricingCurrency()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for pricing_currency: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("PricingCurrency", val, .parse_PricingCurrency())
 
             private$value <- val
         },

--- a/R/pricing_interval.R
+++ b/R/pricing_interval.R
@@ -22,12 +22,9 @@ PricingInterval <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_PricingInterval()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for pricing_interval: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("PricingInterval", val, .parse_PricingInterval())
 
             private$value <- val
         },

--- a/R/pricing_interval.R
+++ b/R/pricing_interval.R
@@ -24,11 +24,11 @@ PricingInterval <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_PricingInterval()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for pricing_interval: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/pricing_type.R
+++ b/R/pricing_type.R
@@ -24,11 +24,11 @@ PricingType <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_PricingType()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for pricing_type: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/pricing_type.R
+++ b/R/pricing_type.R
@@ -22,12 +22,9 @@ PricingType <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_PricingType()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for pricing_type: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("PricingType", val, .parse_PricingType())
 
             private$value <- val
         },

--- a/R/pricing_unit_label.R
+++ b/R/pricing_unit_label.R
@@ -22,12 +22,9 @@ PricingUnitLabel <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_PricingUnitLabel()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for pricing_unit_label: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("PricingUnitLabel", val, .parse_PricingUnitLabel())
 
             private$value <- val
         },

--- a/R/pricing_unit_label.R
+++ b/R/pricing_unit_label.R
@@ -24,11 +24,11 @@ PricingUnitLabel <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_PricingUnitLabel()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for pricing_unit_label: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/public_share_filter.R
+++ b/R/public_share_filter.R
@@ -24,11 +24,11 @@ PublicShareFilter <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_PublicShareFilter()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for public_share_filter: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/public_share_filter.R
+++ b/R/public_share_filter.R
@@ -22,12 +22,9 @@ PublicShareFilter <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_PublicShareFilter()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for public_share_filter: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("PublicShareFilter", val, .parse_PublicShareFilter())
 
             private$value <- val
         },

--- a/R/querystatus.R
+++ b/R/querystatus.R
@@ -22,12 +22,9 @@ Querystatus <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_Querystatus()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for query_status: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("Querystatus", val, .parse_Querystatus())
 
             private$value <- val
         },

--- a/R/querystatus.R
+++ b/R/querystatus.R
@@ -24,11 +24,11 @@ Querystatus <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_Querystatus()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for query_status: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/querytype.R
+++ b/R/querytype.R
@@ -22,12 +22,9 @@ Querytype <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_Querytype()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for query_type: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("Querytype", val, .parse_Querytype())
 
             private$value <- val
         },

--- a/R/querytype.R
+++ b/R/querytype.R
@@ -24,11 +24,11 @@ Querytype <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_Querytype()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for query_type: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/result_format.R
+++ b/R/result_format.R
@@ -22,12 +22,8 @@ ResultFormat <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_ResultFormat()
 
-            # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for result_format: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("ResultFormat", val, .parse_ResultFormat())
 
             private$value <- val
         },

--- a/R/result_format.R
+++ b/R/result_format.R
@@ -24,11 +24,11 @@ ResultFormat <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_ResultFormat()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for result_format: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/sso_provider.R
+++ b/R/sso_provider.R
@@ -24,11 +24,11 @@ SSOProvider <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_SSOProvider()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for sso_provider: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/sso_provider.R
+++ b/R/sso_provider.R
@@ -22,12 +22,9 @@ SSOProvider <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_SSOProvider()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for sso_provider: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("SSOProvider", val, .parse_SSOProvider())
 
             private$value <- val
         },

--- a/R/token_scope.R
+++ b/R/token_scope.R
@@ -24,11 +24,11 @@ TokenScope <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_TokenScope()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for token_scope: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/token_scope.R
+++ b/R/token_scope.R
@@ -22,12 +22,9 @@ TokenScope <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_TokenScope()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for token_scope: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("TokenScope", val, .parse_TokenScope())
 
             private$value <- val
         },

--- a/R/udf_actions.R
+++ b/R/udf_actions.R
@@ -24,11 +24,11 @@ UDFActions <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_UDFActions()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for udf_actions: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/udf_actions.R
+++ b/R/udf_actions.R
@@ -22,12 +22,9 @@ UDFActions <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_UDFActions()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for udf_actions: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("UDFActions", val, .parse_UDFActions())
 
             private$value <- val
         },

--- a/R/udf_language.R
+++ b/R/udf_language.R
@@ -22,12 +22,9 @@ UDFLanguage <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_UDFLanguage()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for udf_language: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("UDFLanguage", val, .parse_UDFLanguage())
 
             private$value <- val
         },

--- a/R/udf_language.R
+++ b/R/udf_language.R
@@ -24,11 +24,11 @@ UDFLanguage <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_UDFLanguage()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for udf_language: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {

--- a/R/udf_type.R
+++ b/R/udf_type.R
@@ -22,12 +22,9 @@ UDFType <- R6::R6Class(
         initialize = function(...) {
             local.optional.var <- list(...)
             val <- unlist(local.optional.var)
-            enumvec <- .parse_UDFType()
 
             # MANUAL EDIT AFTER OPENAPI AUTOGEN
-            if ((length(val) != 1L) || (!val %in% enumvec))
-                stop("Use one of the valid values for udf_type: ",
-                    paste0(enumvec, collapse = ", "))
+            .check_openapi_enum("UDFType", val, .parse_UDFType())
 
             private$value <- val
         },

--- a/R/udf_type.R
+++ b/R/udf_type.R
@@ -24,11 +24,11 @@ UDFType <- R6::R6Class(
             val <- unlist(local.optional.var)
             enumvec <- .parse_UDFType()
 
-            stopifnot(length(val) == 1L)
-
-            if (!val %in% enumvec)
-                stop("Use one of the valid values: ",
+            # MANUAL EDIT AFTER OPENAPI AUTOGEN
+            if ((length(val) != 1L) || (!val %in% enumvec))
+                stop("Use one of the valid values for udf_type: ",
                     paste0(enumvec, collapse = ", "))
+
             private$value <- val
         },
         toJSON = function() {


### PR DESCRIPTION
Continued from https://github.com/TileDB-Inc/TileDB-Cloud-R/pull/75

Context:

* Checking user-supplied strings against acceptable enum-values is done in one place per class, which has access to the list of acceptable values via OpenAPI autogen from the API-schema XML
* We shouldn't duplicate this at various higher-level callsites
* However we should do a better job of wording the error messages

```
> ResultFormat$new(NULL)
Error in initialize(...) :
  Use one of the valid values for result_format: native, json, arrow
> ResultFormat$new('lala')
Error in initialize(...) :
  Use one of the valid values for result_format: native, json, arrow
```