### PR TITLE
Delayed execution of registered UDFs

### DIFF
--- a/inst/tinytest/test_d_delayed_6.R
+++ b/inst/tinytest/test_d_delayed_6.R
@@ -64,3 +64,30 @@ a <- delayed_array_udf(
 )
 o <- compute(a, namespace=namespaceToCharge)
 expect_equal(o, list(min=1, med=3.5, max=6))
+
+a <- delayed_array_udf(
+  namespace=namespaceToCharge,
+  array="TileDB-Inc/quickstart_dense",
+  udf=function(df) {
+    vec <- as.vector(df[["a"]])
+    sum(vec ** 3)
+  },
+  selectedRanges=list(cbind(1,4), cbind(1,4)),
+  attrs=c("a")
+)
+o <- compute(a, namespace=namespaceToCharge)
+expect_equal(o, 18496)
+
+a <- delayed_array_udf(
+  namespace=namespaceToCharge,
+  array="TileDB-Inc/quickstart_dense",
+  udf=function(df, exponent) {
+    vec <- as.vector(df[["a"]])
+    sum(vec ** exponent)
+  },
+  args=list(exponent=3),
+  selectedRanges=list(cbind(1,4), cbind(1,4)),
+  attrs=c("a")
+)
+o <- compute(a, namespace=namespaceToCharge)
+expect_equal(o, 18496)

--- a/inst/tinytest/test_d_delayed_6.R
+++ b/inst/tinytest/test_d_delayed_6.R
@@ -91,3 +91,21 @@ a <- delayed_array_udf(
 )
 o <- compute(a, namespace=namespaceToCharge)
 expect_equal(o, 18496)
+
+# ----------------------------------------------------------------
+# Test invoking registered UDFs
+
+# This one we require to be already registered in prod -- we don't dynamically register it,
+# then test it, then deregister it. We'll do similarly for a Python UDF.
+#
+# myfunc <- function(vec, exponent) { sum(vec ** exponent) }
+# register_udf(namespace='johnkerl-tiledb', name=tiledb-cloud-r-generic-udf-r, type='generic', func=myfunc)
+
+a <- delayed_generic_udf(
+  namespace=namespaceToCharge,
+  registered_udf_name='johnkerl-tiledb/tiledb-cloud-r-generic-udf-r',
+  args=list(vec=1:10, exponent=3),
+  name='my generic udf'
+)
+o <- compute(a)
+expect_equal(o, 3025)

--- a/man/delayed_array_udf.Rd
+++ b/man/delayed_array_udf.Rd
@@ -4,18 +4,40 @@
 \alias{delayed_array_udf}
 \title{Define a single-array UDF to be executed within a task graph}
 \usage{
-delayed_array_udf(namespace, array, udf, selectedRanges, attrs)
+delayed_array_udf(
+  namespace,
+  array,
+  udf = NULL,
+  registered_udf_name = NULL,
+  selectedRanges,
+  attrs,
+  layout = NULL,
+  args = NULL,
+  result_format = "native",
+  name = NULL
+)
 }
 \arguments{
 \item{namespace}{The TileDB-Cloud namespace to charge the query to}
 
 \item{array}{TileDB URI -- see vignette for examples.}
 
-\item{udf}{User-defined function, as in UDF examples.}
+\item{udf}{User-defined function, as in UDF examples. Arguments are specified separately via \code{args}.
+One of \code{udf} and \code{registered_udf_name} must be non-null.}
+
+\item{registered_udf_name}{Name of a registered UDF, of the form \code{namespace/udfname}.
+Arguments are specified separately via \code{args}.  One of \code{udf} and
+\code{registered_udf_name} must be non-null.}
 
 \item{selectedRanges}{As in UDF examples.}
 
 \item{attrs}{As in UDF examples.}
+
+\item{layout}{As in UDF examples.}
+
+\item{result_format}{As in UDF examples.}
+
+\item{name}{A display name for the query}
 }
 \value{
 The return value from the UDF as an R object.


### PR DESCRIPTION
Continuing to flesh out options for delayed execution. Here, we make the delayed versions of generic/array UDFs take all the flags their non-delayed versions do.

Essential snippet from `inst/tinytest/test_d_delayed_6.R`:

```
# Setup:
# myfunc <- function(vec, exponent) { sum(vec ** exponent) }
# register_udf(namespace='johnkerl-tiledb', name=tiledb-cloud-r-generic-udf-r, type='generic', func=myfunc)

a <- delayed_generic_udf(
  namespace=namespaceToCharge,
  registered_udf_name='johnkerl-tiledb/tiledb-cloud-r-generic-udf-r',
  args=list(vec=1:10, exponent=3),
  name='my generic udf'
)
o <- compute(a)
expect_equal(o, 3025)
```