### PR TITLE
Have show(node) handle uncattable results

### DIFF
--- a/R/manual_layer_node.R
+++ b/R/manual_layer_node.R
@@ -315,8 +315,15 @@ Node <- R6::R6Class(
       cat(",args_ready=", ifelse(self$have_args, self$args_ready(), "(none set)"), sep="")
       cat(",future=", ifelse(is.null(self$future), "absent", "present"), sep="")
       cat(",status=", self$status, sep="")
-      cat(",result=", ifelse(is.null(self$result), "(null)", self$result), sep="")
       cat("\n")
+
+      if (!is.null(self$result)) {
+        cat("Result:\n")
+        str(self$result)
+      }
+
+
+
       if (!is.null(self$dag_for_terminal)) {
         show(self$dag_for_terminal)
       }


### PR DESCRIPTION
# Summary

R has a few print-related functions: `print`, `cat`, `str` to name three. For printing multiple things, `cat` is a workhorse` -- it takes varargs and prints everything it's passed. One caveat, though, not everything is cattable. In the `show` generic for the `Node` class we were using `cat` for multiple side-by-side things including the UDF result -- which is under the user's control and may or may not be cattable.

On this PR we simply switch to `str` for this.

# Example

Wrap a `sum(...)` (which is cattable) inside a `list` (which is not).

Before:

```
> a <- delayed(function(...){list(sum(...))}, args=list(1,2),local=TRUE)

> compute(a)
[[1]]
[1] 3

> show(a)
node=n000001,nargs=2,args_ready=TRUE,future=absent,status=COMPLETED,result=Error in cat(",result=", ifelse(is.null(self$result), "(null)", self$result),  :
  argument 2 (type 'list') cannot be handled by 'cat'
```

After:

```
> a <- delayed(function(...){list(sum(...))}, args=list(1,2),local=TRUE)

> compute(a)
[[1]]
[1] 3

> show(a)
node=n000001,nargs=2,args_ready=TRUE,future=absent,status=COMPLETED
result:
List of 1
 $ : num 3
Namespace: NULL
All      nodes:    (1) n000001
Initial  nodes:    (1) n000001
Terminal node:     (1) n000001
Dependencies:
  n000001 (0)
Statuses:
  n000001  args_ready=TRUE status=COMPLETED
```