### PR TITLE
Put namespace argument first

### DIFF
--- a/R/manual_layer_delayed.R
+++ b/R/manual_layer_delayed.R
@@ -55,7 +55,7 @@ delayed_sql <- function(namespace, query, name) {
   # server calling itself -- not only would that be a circular dependency, but
   # moreover the tiledbcloud is not running on the REST server.
   delayed(function() {
-    execute_sql_query(namespace=namespace, query=query, name=name, namespace=namespace)
+    execute_sql_query(namespace=namespace, query=query, name=name)
   }, local=TRUE)
 }
 

--- a/R/manual_layer_delayed.R
+++ b/R/manual_layer_delayed.R
@@ -37,11 +37,11 @@ delayed <- function(func, args=NULL, name=NULL, local=FALSE) {
 
 ##' Define a SQL query function to be executed within a task graph
 ##'
+##' @param namespace The TileDB-Cloud namespace to charge the query to
+##'
 ##' @param query SQL query string -- see vignette for examples
 ##'
 ##' @param name A display name for the query
-##'
-##' @param namespace The TileDB-Cloud namespace to charge the query to
 ##'
 ##' @return A task-graph node object on which you can later call \code{compute}.  The return value from
 ##' compute() will be the query result as a dataframe.  Note that results will be strings, so numerical
@@ -49,13 +49,13 @@ delayed <- function(func, args=NULL, name=NULL, local=FALSE) {
 ##'
 ##' @family {manual-layer functions}
 ##' @export
-delayed_sql <- function(query, name, namespace) {
+delayed_sql <- function(namespace, query, name) {
   # It is absolutely necessary that this be a locally executing call to the
   # remote REST service. A non-local execution of this would mean the REST
   # server calling itself -- not only would that be a circular dependency, but
   # moreover the tiledbcloud is not running on the REST server.
   delayed(function() {
-    execute_sql_query(query=query, name=name, namespace=namespace)
+    execute_sql_query(namespace=namespace, query=query, name=name, namespace=namespace)
   }, local=TRUE)
 }
 

--- a/R/manual_layer_sql.R
+++ b/R/manual_layer_sql.R
@@ -8,16 +8,16 @@
 ##' The \code{udf} and \code{namespace} arguments are required; the \code{args}
 ##' argument is optional.
 ##'
+##' @param namespace Namespace within TileDB cloud.
+##'
 ##' @param query SQL query as a string.
 ##'
 ##' @param name A descriptive name to give the query.
 ##'
-##' @param namespace Namespace within TileDB cloud.
-##'
 ##' @return The result of the SQL query.
 ##' @family {manual-layer functions}
 ##' @export
-execute_sql_query <- function(query, name, namespace) {
+execute_sql_query <- function(namespace, query, name) {
 
   api.client.instance <- get_api_client_instance()
   sql.api.instance <- sql <- SqlApi$new(api.client.instance)

--- a/inst/tinytest/test_d_delayed_6.R
+++ b/inst/tinytest/test_d_delayed_6.R
@@ -25,9 +25,9 @@ library(tiledbcloud)
 
 # ----------------------------------------------------------------
 a <- delayed_sql(
+    namespace=namespaceToCharge,
     query="select `rows`, AVG(a) as avg_a from `tiledb://TileDB-Inc/quickstart_dense` GROUP BY `rows`",
-    name="rows-query",
-    namespace=namespaceToCharge)
+    name="rows-query")
 o <- compute(a, namespaceToCharge)
 expect_equal(names(o), c("avg_a", "rows"))
 expect_equal(rownames(o), c("1", "2", "3", "4"))

--- a/vignettes/SQL.Rmd
+++ b/vignettes/SQL.Rmd
@@ -13,15 +13,15 @@ Script:
 namespace <- "yournamespace"
 
 ans <- execute_sql_query(
+  namespace=namespacej
   query="select `rows`, AVG(a) as avg_a from `tiledb://TileDB-Inc/quickstart_dense` GROUP BY `rows`",
-  name="rows-query",
-  namespace=namespace)
+  name="rows-query")
 show(ans)
 
 ans <- execute_sql_query(
+  namespace=namespace,
   query="select `rows`, AVG(a) as avg_a from `tiledb://TileDB-Inc/oops_a_typo` GROUP BY `rows`",
-  name="rows-query",
-  namespace=namespace)
+  name="rows-query")
 show(ans)
 ```
 

--- a/vignettes/TaskGraphs.Rmd
+++ b/vignettes/TaskGraphs.Rmd
@@ -40,9 +40,9 @@ This is a simple convenience wrapper connecting `delayed`, as above, and TileDB 
 
 ```
 a <- delayed_sql(
+    namespace='your-namespace',
     query="select `rows`, AVG(a) as avg_a from `tiledb://TileDB-Inc/quickstart_dense` GROUP BY `rows`",
-    name="rows-query",
-    namespace='your-namespace')
+    name="rows-query")
 o <- compute(a, namespace, verbose=TRUE)
 print(o)
 ```
@@ -140,9 +140,9 @@ array_apply <- delayed_array_udf(
 # SQL -- note the output is a dataframe, and values are all strings (MariaDB
 # "decimal values") so we'll cast them to numeric later.
 sql = delayed_sql(
+  namespace=namespace,
   "select SUM(`a`) as a from `tiledb://TileDB-Inc/quickstart_dense`",
-  name="sql",
-  namespace=namespace
+  name="sql"
 )
 
 # Custom function for averaging all the results we are passing in


### PR DESCRIPTION
A survey of recent manual-layer methods shows that `execute_sql_query` and `delayed_sql` had the `namespace` argument last, not first as the rest do.