### PR TITLE
Remove unnecessary caching of namespace in DAG

### DIFF
--- a/R/manual_layer_node.R
+++ b/R/manual_layer_node.R
@@ -112,11 +112,8 @@ Node <- R6::R6Class(
     # Nominal use-case is people call compute(...) on a return value from delayed(...).
     # However, for more detailed inspection we support getting a DAG and doing dag$poll()
     # and inspecting the results as computation progresses.
-    #
-    # The namespace must be non-null for cloud execution. For all-local runs it can be null.
-    # We check this at compute time.
-    make_dag = function(namespace=NULL) {
-      self$dag_for_terminal <- DAG$new(namespace=namespace, terminal_node=self)
+    make_dag = function() {
+      self$dag_for_terminal <- DAG$new(terminal_node=self)
       self$dag_for_terminal
     },
 
@@ -145,10 +142,10 @@ Node <- R6::R6Class(
       # or failed) people can show(n$dag_for_terminal) to visualize future results, stdout from the
       # forked processes, etc.
       if (is.null(self$dag_for_terminal)) {
-        self$make_dag(namespace)
+        self$make_dag()
       }
 
-      self$dag_for_terminal$compute(timeout_seconds=timeout_seconds, verbose=verbose, force_all_local=force_all_local)
+      self$dag_for_terminal$compute(namespace=namespace, timeout_seconds=timeout_seconds, verbose=verbose, force_all_local=force_all_local)
     },
 
     # ----------------------------------------------------------------
@@ -159,7 +156,7 @@ Node <- R6::R6Class(
     #
     # Our DAG is a poll-driven DAG so dag$poll() must be called repeatedly in order to launch
     # futures for initial nodes, detect when they are resolved, launch subsequent nodes, etc.
-    poll = function(namespace, verbose=FALSE, force_local=FALSE) {
+    poll = function(namespace=NULL, verbose=FALSE, force_local=FALSE) {
       if (is.null(namespace)) {
         if (!self$local && !force_local) {
           stop("namespace must be provided in a task graph with any non-local nodes.")

--- a/inst/tinytest/test_a_delayed_2.R
+++ b/inst/tinytest/test_a_delayed_2.R
@@ -18,11 +18,10 @@ check_topo_sort <- function(dag, name1, name2) {
 # ----------------------------------------------------------------
 a <- delayed(function() { 1 }, name='a', local=TRUE)
 
-dag <- DAG$new(namespace="ns", terminal_node=a)
+dag <- DAG$new(terminal_node=a)
 
 expect_equal(length(dag$all_nodes), 1)
 expect_equal(length(dag$initial_nodes), 1)
-expect_equal(dag$namespace, 'ns')
 
 # ----------------------------------------------------------------
 a <- delayed(function()    {      1 },               name='a', local=TRUE)
@@ -31,11 +30,10 @@ c <- delayed(function()  {      300 },               name='c', local=TRUE)
 d <- delayed(function(x) {   4000+x }, args=list(c), name='d', local=TRUE)
 e <- delayed(function(x,y) {  50000+x+y }, args=list(b,d), name='e', local=TRUE)
 
-dag <- DAG$new(namespace="ns", terminal_node=e)
+dag <- DAG$new(terminal_node=e)
 
 expect_equal(length(dag$all_nodes), 5)
 expect_equal(length(dag$initial_nodes), 2)
-expect_equal(dag$namespace, 'ns')
 
 check_topo_sort(dag, 'a', 'b')
 check_topo_sort(dag, 'c', 'd')
@@ -53,11 +51,10 @@ e <- delayed(function(x) {  50000+x }, args=list(d), name='e', local=TRUE)
 f <- delayed(function(x) { 600000+x }, args=list(e), name='f', local=TRUE)
 g <- delayed(function(x) {7000000+x }, args=list(f), name='g', local=TRUE)
 
-dag <- DAG$new(namespace="ns", terminal_node=g)
+dag <- DAG$new(terminal_node=g)
 
 expect_equal(length(dag$all_nodes), 7)
 expect_equal(length(dag$initial_nodes), 1)
-expect_equal(dag$namespace, 'ns')
 
 check_topo_sort(dag, 'a', 'b')
 check_topo_sort(dag, 'b', 'c')
@@ -76,11 +73,10 @@ e <- delayed(sum, args=list(c,d),   name='e')
 f <- delayed(sum, args=list(c),     name='f')
 g <- delayed(sum, args=list(a,e,f), name='g')
 
-dag <- DAG$new(namespace="ns", terminal_node=g)
+dag <- DAG$new(terminal_node=g)
 
 expect_equal(length(dag$all_nodes), 7)
 expect_equal(length(dag$initial_nodes), 3)
-expect_equal(dag$namespace, 'ns')
 
 check_topo_sort(dag, 'a', 'd')
 check_topo_sort(dag, 'a', 'g')


### PR DESCRIPTION
The `namespace` argument to `compute` can and should be passed on the stack. Caching it in the `DAG` object is unnecessary and can lead to confusion.

In future we may need to compute different nodes in different namespaces, and this PR clears the way. If namespaces need to be cached anywhere, it will be in individual `Node` objects, not in the `DAG` object.

(Another ask on a previous code review was that when the namespace is absent, we default it from the logged-in users prefs. This PR does not do that; #86 does.)