### PR TITLE
Take default namespace from logged-in user account

### DIFF
--- a/R/manual_layer_login.R
+++ b/R/manual_layer_login.R
@@ -91,11 +91,20 @@ login <- function(username, password, api_key, host, remember_me=TRUE, write_con
     .pkgenv[["apiClientInstance"]]  <- apiClientInstance
     .pkgenv[["userApiInstance"]] <- userApiInstance
 
+    ## Remember default namespace. Set this even if it's NULL -- the fact that
+    ## the user doesn't have a default namespace to charge is itself worth remembering,
+    ## so that error messages in the default-namespacing logic can be more helpful.
+    .pkgenv[["default_namespace_charged"]] <- res[["default_namespace_charged"]]
+
     if (write_config) {
       .storeConfig()
     }
 
     invisible()
+}
+
+.get_default_namespace_charged <- function() {
+  .pkgenv[["default_namespace_charged"]]
 }
 
 ##' Access cached API-client object

--- a/R/manual_layer_node.R
+++ b/R/manual_layer_node.R
@@ -160,9 +160,10 @@ Node <- R6::R6Class(
     # Our DAG is a poll-driven DAG so dag$poll() must be called repeatedly in order to launch
     # futures for initial nodes, detect when they are resolved, launch subsequent nodes, etc.
     poll = function(namespace, verbose=FALSE, force_local=FALSE) {
-      if (is.null(namespace)) {
-        if (!self$local && !force_local) {
-          stop("namespace must be provided in a task graph with any non-local nodes.")
+      if (is.null(namespace) && (!self$local && !force_local)) {
+        namespace <- .get_default_namespace_charged()
+        if (is.null(namespace)) {
+          stop("namespace must be provided in a task graph with any non-local nodes, and no account-local default was found")
         }
       }
       if (self$status == COMPLETED) {

--- a/inst/tinytest/test_d_delayed_5.R
+++ b/inst/tinytest/test_d_delayed_5.R
@@ -25,7 +25,7 @@ library(tiledbcloud)
 
 # ----------------------------------------------------------------
 a <- delayed(function() { 9 }, name='a', local=FALSE)
-expect_error(compute(a, timeout_seconds=300),
+expect_error(compute(a, namespace=NULL< timeout_seconds=300),
   pattern="namespace must be provided in a task graph with any non-local nodes")
 
 # ----------------------------------------------------------------

--- a/inst/tinytest/test_d_delayed_5.R
+++ b/inst/tinytest/test_d_delayed_5.R
@@ -25,7 +25,7 @@ library(tiledbcloud)
 
 # ----------------------------------------------------------------
 a <- delayed(function() { 9 }, name='a', local=FALSE)
-expect_error(compute(a, namespace=NULL< timeout_seconds=300),
+expect_error(compute(a, namespace=NULL, timeout_seconds=300),
   pattern="namespace must be provided in a task graph with any non-local nodes")
 
 # ----------------------------------------------------------------


### PR DESCRIPTION
As requested by @ihnorton on https://github.com/TileDB-Inc/TileDB-Cloud-R/pull/56