### PR TITLE
Fix OpenAPI-autogen bugs in enum JSON parse

### DIFF
--- a/R/array.R
+++ b/R/array.R
@@ -67,8 +67,14 @@ Array <- R6::R6Class(
         self$`timestamp` <- ArrayObject$`timestamp`
       }
       if (!is.null(ArrayObject$`queryType`)) {
-        queryTypeObject <- Querytype$new()
-        queryTypeObject$fromJSON(jsonlite::toJSON(ArrayObject$queryType, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #queryTypeObject <- Querytype$new()
+        #queryTypeObject$fromJSON(jsonlite::toJSON(ArrayObject$queryType, auto_unbox = TRUE, digits = NA))
+        queryTypeObject <- Querytype$new(ArrayObject$queryType)
         self$`queryType` <- queryTypeObject
       }
       if (!is.null(ArrayObject$`uri`)) {

--- a/R/array_activity_log.R
+++ b/R/array_activity_log.R
@@ -134,8 +134,14 @@ ArrayActivityLog <- R6::R6Class(
         self$`event_at` <- ArrayActivityLogObject$`event_at`
       }
       if (!is.null(ArrayActivityLogObject$`action`)) {
-        actionObject <- ActivityEventType$new()
-        actionObject$fromJSON(jsonlite::toJSON(ArrayActivityLogObject$action, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #actionObject <- ActivityEventType$new()
+        #actionObject$fromJSON(jsonlite::toJSON(ArrayActivityLogObject$action, auto_unbox = TRUE, digits = NA))
+        actionObject <- ActivityEventType$new(ArrayActivityLogObject$action)
         self$`action` <- actionObject
       }
       if (!is.null(ArrayActivityLogObject$`username`)) {

--- a/R/array_info_update.R
+++ b/R/array_info_update.R
@@ -163,8 +163,14 @@ ArrayInfoUpdate <- R6::R6Class(
         self$`uri` <- ArrayInfoUpdateObject$`uri`
       }
       if (!is.null(ArrayInfoUpdateObject$`file_type`)) {
-        file_typeObject <- FileType$new()
-        file_typeObject$fromJSON(jsonlite::toJSON(ArrayInfoUpdateObject$file_type, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #file_typeObject <- FileType$new()
+        #file_typeObject$fromJSON(jsonlite::toJSON(ArrayInfoUpdateObject$file_type, auto_unbox = TRUE, digits = NA))
+        file_typeObject <- FileType$new(ArrayInfoUpdateObject$file_type)
         self$`file_type` <- file_typeObject
       }
       if (!is.null(ArrayInfoUpdateObject$`file_properties`)) {

--- a/R/array_schema.R
+++ b/R/array_schema.R
@@ -160,18 +160,36 @@ ArraySchema <- R6::R6Class(
         self$`version` <- ApiClient$new()$deserializeObj(ArraySchemaObject$`version`, "array[integer]", loadNamespace("tiledbcloud"))
       }
       if (!is.null(ArraySchemaObject$`arrayType`)) {
-        arrayTypeObject <- ArrayType$new()
-        arrayTypeObject$fromJSON(jsonlite::toJSON(ArraySchemaObject$arrayType, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #arrayTypeObject <- ArrayType$new()
+        #arrayTypeObject$fromJSON(jsonlite::toJSON(ArraySchemaObject$arrayType, auto_unbox = TRUE, digits = NA))
+        arrayTypeObject <- ArrayType$new(ArraySchemaObject$arrayType)
         self$`arrayType` <- arrayTypeObject
       }
       if (!is.null(ArraySchemaObject$`tileOrder`)) {
-        tileOrderObject <- Layout$new()
-        tileOrderObject$fromJSON(jsonlite::toJSON(ArraySchemaObject$tileOrder, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #tileOrderObject <- Layout$new()
+        #tileOrderObject$fromJSON(jsonlite::toJSON(ArraySchemaObject$tileOrder, auto_unbox = TRUE, digits = NA))
+        tileOrderObject <- Layout$new(ArraySchemaObject$tileOrder)
         self$`tileOrder` <- tileOrderObject
       }
       if (!is.null(ArraySchemaObject$`cellOrder`)) {
-        cellOrderObject <- Layout$new()
-        cellOrderObject$fromJSON(jsonlite::toJSON(ArraySchemaObject$cellOrder, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #cellOrderObject <- Layout$new()
+        #cellOrderObject$fromJSON(jsonlite::toJSON(ArraySchemaObject$cellOrder, auto_unbox = TRUE, digits = NA))
+        cellOrderObject <- Layout$new(ArraySchemaObject$cellOrder)
         self$`cellOrder` <- cellOrderObject
       }
       if (!is.null(ArraySchemaObject$`capacity`)) {

--- a/R/array_task.R
+++ b/R/array_task.R
@@ -357,8 +357,14 @@ ArrayTask <- R6::R6Class(
         self$`access_cost` <- ArrayTaskObject$`access_cost`
       }
       if (!is.null(ArrayTaskObject$`query_type`)) {
-        query_typeObject <- Querytype$new()
-        query_typeObject$fromJSON(jsonlite::toJSON(ArrayTaskObject$query_type, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #query_typeObject <- Querytype$new()
+        #query_typeObject$fromJSON(jsonlite::toJSON(ArrayTaskObject$query_type, auto_unbox = TRUE, digits = NA))
+        query_typeObject <- Querytype$new(ArrayTaskObject$query_type)
         self$`query_type` <- query_typeObject
       }
       if (!is.null(ArrayTaskObject$`udf_code`)) {
@@ -371,8 +377,14 @@ ArrayTask <- R6::R6Class(
         self$`sql_query` <- ArrayTaskObject$`sql_query`
       }
       if (!is.null(ArrayTaskObject$`type`)) {
-        typeObject <- ArrayTaskType$new()
-        typeObject$fromJSON(jsonlite::toJSON(ArrayTaskObject$type, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #typeObject <- ArrayTaskType$new()
+        #typeObject$fromJSON(jsonlite::toJSON(ArrayTaskObject$type, auto_unbox = TRUE, digits = NA))
+        typeObject <- ArrayTaskType$new(ArrayTaskObject$type)
         self$`type` <- typeObject
       }
       if (!is.null(ArrayTaskObject$`activity`)) {

--- a/R/attribute.R
+++ b/R/attribute.R
@@ -91,8 +91,14 @@ Attribute <- R6::R6Class(
         self$`name` <- AttributeObject$`name`
       }
       if (!is.null(AttributeObject$`type`)) {
-        typeObject <- Datatype$new()
-        typeObject$fromJSON(jsonlite::toJSON(AttributeObject$type, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #typeObject <- Datatype$new()
+        #typeObject$fromJSON(jsonlite::toJSON(AttributeObject$type, auto_unbox = TRUE, digits = NA))
+        typeObject <- Datatype$new(AttributeObject$type)
         self$`type` <- typeObject
       }
       if (!is.null(AttributeObject$`filterPipeline`)) {

--- a/R/dimension.R
+++ b/R/dimension.R
@@ -100,8 +100,14 @@ Dimension <- R6::R6Class(
         self$`name` <- DimensionObject$`name`
       }
       if (!is.null(DimensionObject$`type`)) {
-        typeObject <- Datatype$new()
-        typeObject$fromJSON(jsonlite::toJSON(DimensionObject$type, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #typeObject <- Datatype$new()
+        #typeObject$fromJSON(jsonlite::toJSON(DimensionObject$type, auto_unbox = TRUE, digits = NA))
+        typeObject <- Datatype$new(DimensionObject$type)
         self$`type` <- typeObject
       }
       if (!is.null(DimensionObject$`domain`)) {

--- a/R/domain.R
+++ b/R/domain.R
@@ -77,18 +77,36 @@ Domain <- R6::R6Class(
     fromJSON = function(DomainJson) {
       DomainObject <- jsonlite::fromJSON(DomainJson)
       if (!is.null(DomainObject$`type`)) {
-        typeObject <- Datatype$new()
-        typeObject$fromJSON(jsonlite::toJSON(DomainObject$type, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #typeObject <- Datatype$new()
+        #typeObject$fromJSON(jsonlite::toJSON(DomainObject$type, auto_unbox = TRUE, digits = NA))
+        typeObject <- Datatype$new(DomainObject$type)
         self$`type` <- typeObject
       }
       if (!is.null(DomainObject$`tileOrder`)) {
-        tileOrderObject <- Layout$new()
-        tileOrderObject$fromJSON(jsonlite::toJSON(DomainObject$tileOrder, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #tileOrderObject <- Layout$new()
+        #tileOrderObject$fromJSON(jsonlite::toJSON(DomainObject$tileOrder, auto_unbox = TRUE, digits = NA))
+        tileOrderObject <- Layout$new(DomainObject$tileOrder)
         self$`tileOrder` <- tileOrderObject
       }
       if (!is.null(DomainObject$`cellOrder`)) {
-        cellOrderObject <- Layout$new()
-        cellOrderObject$fromJSON(jsonlite::toJSON(DomainObject$cellOrder, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #cellOrderObject <- Layout$new()
+        #cellOrderObject$fromJSON(jsonlite::toJSON(DomainObject$cellOrder, auto_unbox = TRUE, digits = NA))
+        cellOrderObject <- Layout$new(DomainObject$cellOrder)
         self$`cellOrder` <- cellOrderObject
       }
       if (!is.null(DomainObject$`dimensions`)) {

--- a/R/filter.R
+++ b/R/filter.R
@@ -54,8 +54,14 @@ Filter <- R6::R6Class(
     fromJSON = function(FilterJson) {
       FilterObject <- jsonlite::fromJSON(FilterJson)
       if (!is.null(FilterObject$`type`)) {
-        typeObject <- FilterType$new()
-        typeObject$fromJSON(jsonlite::toJSON(FilterObject$type, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #typeObject <- FilterType$new()
+        #typeObject$fromJSON(jsonlite::toJSON(FilterObject$type, auto_unbox = TRUE, digits = NA))
+        typeObject <- FilterType$new(FilterObject$type)
         self$`type` <- typeObject
       }
       if (!is.null(FilterObject$`data`)) {

--- a/R/generic_udf.R
+++ b/R/generic_udf.R
@@ -156,8 +156,14 @@ GenericUDF <- R6::R6Class(
         self$`udf_info_name` <- GenericUDFObject$`udf_info_name`
       }
       if (!is.null(GenericUDFObject$`language`)) {
-        languageObject <- UDFLanguage$new()
-        languageObject$fromJSON(jsonlite::toJSON(GenericUDFObject$language, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #languageObject <- UDFLanguage$new()
+        #languageObject$fromJSON(jsonlite::toJSON(GenericUDFObject$language, auto_unbox = TRUE, digits = NA))
+        languageObject <- UDFLanguage$new(GenericUDFObject$language)
         self$`language` <- languageObject
       }
       if (!is.null(GenericUDFObject$`version`)) {
@@ -179,8 +185,14 @@ GenericUDF <- R6::R6Class(
         self$`stored_param_uuids` <- ApiClient$new()$deserializeObj(GenericUDFObject$`stored_param_uuids`, "array[character]", loadNamespace("tiledbcloud"))
       }
       if (!is.null(GenericUDFObject$`result_format`)) {
-        result_formatObject <- ResultFormat$new()
-        result_formatObject$fromJSON(jsonlite::toJSON(GenericUDFObject$result_format, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #result_formatObject <- ResultFormat$new()
+        #result_formatObject$fromJSON(jsonlite::toJSON(GenericUDFObject$result_format, auto_unbox = TRUE, digits = NA))
+        result_formatObject <- ResultFormat$new(GenericUDFObject$result_format)
         self$`result_format` <- result_formatObject
       }
       if (!is.null(GenericUDFObject$`task_name`)) {

--- a/R/invitation.R
+++ b/R/invitation.R
@@ -200,8 +200,14 @@ Invitation <- R6::R6Class(
         self$`id` <- InvitationObject$`id`
       }
       if (!is.null(InvitationObject$`invitation_type`)) {
-        invitation_typeObject <- InvitationType$new()
-        invitation_typeObject$fromJSON(jsonlite::toJSON(InvitationObject$invitation_type, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #invitation_typeObject <- InvitationType$new()
+        #invitation_typeObject$fromJSON(jsonlite::toJSON(InvitationObject$invitation_type, auto_unbox = TRUE, digits = NA))
+        invitation_typeObject <- InvitationType$new(InvitationObject$invitation_type)
         self$`invitation_type` <- invitation_typeObject
       }
       if (!is.null(InvitationObject$`owner_namespace_uuid`)) {
@@ -217,8 +223,14 @@ Invitation <- R6::R6Class(
         self$`organization_name` <- InvitationObject$`organization_name`
       }
       if (!is.null(InvitationObject$`organization_role`)) {
-        organization_roleObject <- OrganizationRoles$new()
-        organization_roleObject$fromJSON(jsonlite::toJSON(InvitationObject$organization_role, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #organization_roleObject <- OrganizationRoles$new()
+        #organization_roleObject$fromJSON(jsonlite::toJSON(InvitationObject$organization_role, auto_unbox = TRUE, digits = NA))
+        organization_roleObject <- OrganizationRoles$new(InvitationObject$organization_role)
         self$`organization_role` <- organization_roleObject
       }
       if (!is.null(InvitationObject$`array_uuid`)) {
@@ -234,8 +246,14 @@ Invitation <- R6::R6Class(
         self$`actions` <- InvitationObject$`actions`
       }
       if (!is.null(InvitationObject$`status`)) {
-        statusObject <- InvitationStatus$new()
-        statusObject$fromJSON(jsonlite::toJSON(InvitationObject$status, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #statusObject <- InvitationStatus$new()
+        #statusObject$fromJSON(jsonlite::toJSON(InvitationObject$status, auto_unbox = TRUE, digits = NA))
+        statusObject <- InvitationStatus$new(InvitationObject$status)
         self$`status` <- statusObject
       }
       if (!is.null(InvitationObject$`created_at`)) {

--- a/R/invitation_organization_join_email.R
+++ b/R/invitation_organization_join_email.R
@@ -70,8 +70,14 @@ InvitationOrganizationJoinEmail <- R6::R6Class(
         self$`actions` <- ApiClient$new()$deserializeObj(InvitationOrganizationJoinEmailObject$`actions`, "array[NamespaceActions]", loadNamespace("tiledbcloud"))
       }
       if (!is.null(InvitationOrganizationJoinEmailObject$`organization_role`)) {
-        organization_roleObject <- OrganizationRoles$new()
-        organization_roleObject$fromJSON(jsonlite::toJSON(InvitationOrganizationJoinEmailObject$organization_role, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #organization_roleObject <- OrganizationRoles$new()
+        #organization_roleObject$fromJSON(jsonlite::toJSON(InvitationOrganizationJoinEmailObject$organization_role, auto_unbox = TRUE, digits = NA))
+        organization_roleObject <- OrganizationRoles$new(InvitationOrganizationJoinEmailObject$organization_role)
         self$`organization_role` <- organization_roleObject
       }
       if (!is.null(InvitationOrganizationJoinEmailObject$`invitee_email`)) {

--- a/R/last_accessed_array.R
+++ b/R/last_accessed_array.R
@@ -98,8 +98,14 @@ LastAccessedArray <- R6::R6Class(
         self$`accessed_time` <- LastAccessedArrayObject$`accessed_time`
       }
       if (!is.null(LastAccessedArrayObject$`access_type`)) {
-        access_typeObject <- ActivityEventType$new()
-        access_typeObject$fromJSON(jsonlite::toJSON(LastAccessedArrayObject$access_type, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #access_typeObject <- ActivityEventType$new()
+        #access_typeObject$fromJSON(jsonlite::toJSON(LastAccessedArrayObject$access_type, auto_unbox = TRUE, digits = NA))
+        access_typeObject <- ActivityEventType$new(LastAccessedArrayObject$access_type)
         self$`access_type` <- access_typeObject
       }
       self

--- a/R/multi_array_udf.R
+++ b/R/multi_array_udf.R
@@ -202,8 +202,14 @@ MultiArrayUDF <- R6::R6Class(
         self$`udf_info_name` <- MultiArrayUDFObject$`udf_info_name`
       }
       if (!is.null(MultiArrayUDFObject$`language`)) {
-        languageObject <- UDFLanguage$new()
-        languageObject$fromJSON(jsonlite::toJSON(MultiArrayUDFObject$language, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #languageObject <- UDFLanguage$new()
+        #languageObject$fromJSON(jsonlite::toJSON(MultiArrayUDFObject$language, auto_unbox = TRUE, digits = NA))
+        languageObject <- UDFLanguage$new(MultiArrayUDFObject$language)
         self$`language` <- languageObject
       }
       if (!is.null(MultiArrayUDFObject$`version`)) {
@@ -219,8 +225,14 @@ MultiArrayUDF <- R6::R6Class(
         self$`exec_raw` <- MultiArrayUDFObject$`exec_raw`
       }
       if (!is.null(MultiArrayUDFObject$`result_format`)) {
-        result_formatObject <- ResultFormat$new()
-        result_formatObject$fromJSON(jsonlite::toJSON(MultiArrayUDFObject$result_format, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #result_formatObject <- ResultFormat$new()
+        #result_formatObject$fromJSON(jsonlite::toJSON(MultiArrayUDFObject$result_format, auto_unbox = TRUE, digits = NA))
+        result_formatObject <- ResultFormat$new(MultiArrayUDFObject$result_format)
         self$`result_format` <- result_formatObject
       }
       if (!is.null(MultiArrayUDFObject$`task_name`)) {

--- a/R/organization.R
+++ b/R/organization.R
@@ -200,8 +200,14 @@ Organization <- R6::R6Class(
         self$`id` <- OrganizationObject$`id`
       }
       if (!is.null(OrganizationObject$`role`)) {
-        roleObject <- OrganizationRoles$new()
-        roleObject$fromJSON(jsonlite::toJSON(OrganizationObject$role, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #roleObject <- OrganizationRoles$new()
+        #roleObject$fromJSON(jsonlite::toJSON(OrganizationObject$role, auto_unbox = TRUE, digits = NA))
+        roleObject <- OrganizationRoles$new(OrganizationObject$role)
         self$`role` <- roleObject
       }
       if (!is.null(OrganizationObject$`name`)) {

--- a/R/organization_user.R
+++ b/R/organization_user.R
@@ -111,8 +111,14 @@ OrganizationUser <- R6::R6Class(
         self$`organization_name` <- OrganizationUserObject$`organization_name`
       }
       if (!is.null(OrganizationUserObject$`role`)) {
-        roleObject <- OrganizationRoles$new()
-        roleObject$fromJSON(jsonlite::toJSON(OrganizationUserObject$role, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #roleObject <- OrganizationRoles$new()
+        #roleObject$fromJSON(jsonlite::toJSON(OrganizationUserObject$role, auto_unbox = TRUE, digits = NA))
+        roleObject <- OrganizationRoles$new(OrganizationUserObject$role)
         self$`role` <- roleObject
       }
       if (!is.null(OrganizationUserObject$`allowed_actions`)) {

--- a/R/pricing.R
+++ b/R/pricing.R
@@ -183,8 +183,14 @@ Pricing <- R6::R6Class(
         self$`pricing_name` <- PricingObject$`pricing_name`
       }
       if (!is.null(PricingObject$`pricing_type`)) {
-        pricing_typeObject <- PricingType$new()
-        pricing_typeObject$fromJSON(jsonlite::toJSON(PricingObject$pricing_type, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #pricing_typeObject <- PricingType$new()
+        #pricing_typeObject$fromJSON(jsonlite::toJSON(PricingObject$pricing_type, auto_unbox = TRUE, digits = NA))
+        pricing_typeObject <- PricingType$new(PricingObject$pricing_type)
         self$`pricing_type` <- pricing_typeObject
       }
       if (!is.null(PricingObject$`product_name`)) {
@@ -194,23 +200,47 @@ Pricing <- R6::R6Class(
         self$`product_statement_descriptor` <- PricingObject$`product_statement_descriptor`
       }
       if (!is.null(PricingObject$`product_unit_label`)) {
-        product_unit_labelObject <- PricingUnitLabel$new()
-        product_unit_labelObject$fromJSON(jsonlite::toJSON(PricingObject$product_unit_label, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #product_unit_labelObject <- PricingUnitLabel$new()
+        #product_unit_labelObject$fromJSON(jsonlite::toJSON(PricingObject$product_unit_label, auto_unbox = TRUE, digits = NA))
+        product_unit_labelObject <- PricingUnitLabel$new(PricingObject$product_unit_label)
         self$`product_unit_label` <- product_unit_labelObject
       }
       if (!is.null(PricingObject$`currency`)) {
-        currencyObject <- PricingCurrency$new()
-        currencyObject$fromJSON(jsonlite::toJSON(PricingObject$currency, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #currencyObject <- PricingCurrency$new()
+        #currencyObject$fromJSON(jsonlite::toJSON(PricingObject$currency, auto_unbox = TRUE, digits = NA))
+        currencyObject <- PricingCurrency$new(PricingObject$currency)
         self$`currency` <- currencyObject
       }
       if (!is.null(PricingObject$`aggregate_usage`)) {
-        aggregate_usageObject <- PricingAggregateUsage$new()
-        aggregate_usageObject$fromJSON(jsonlite::toJSON(PricingObject$aggregate_usage, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #aggregate_usageObject <- PricingAggregateUsage$new()
+        #aggregate_usageObject$fromJSON(jsonlite::toJSON(PricingObject$aggregate_usage, auto_unbox = TRUE, digits = NA))
+        aggregate_usageObject <- PricingAggregateUsage$new(PricingObject$aggregate_usage)
         self$`aggregate_usage` <- aggregate_usageObject
       }
       if (!is.null(PricingObject$`interval`)) {
-        intervalObject <- PricingInterval$new()
-        intervalObject$fromJSON(jsonlite::toJSON(PricingObject$interval, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #intervalObject <- PricingInterval$new()
+        #intervalObject$fromJSON(jsonlite::toJSON(PricingObject$interval, auto_unbox = TRUE, digits = NA))
+        intervalObject <- PricingInterval$new(PricingObject$interval)
         self$`interval` <- intervalObject
       }
       if (!is.null(PricingObject$`divided_by`)) {

--- a/R/query.R
+++ b/R/query.R
@@ -132,18 +132,36 @@ Query <- R6::R6Class(
     fromJSON = function(QueryJson) {
       QueryObject <- jsonlite::fromJSON(QueryJson)
       if (!is.null(QueryObject$`type`)) {
-        typeObject <- Querytype$new()
-        typeObject$fromJSON(jsonlite::toJSON(QueryObject$type, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #typeObject <- Querytype$new()
+        #typeObject$fromJSON(jsonlite::toJSON(QueryObject$type, auto_unbox = TRUE, digits = NA))
+        typeObject <- Querytype$new(QueryObject$type)
         self$`type` <- typeObject
       }
       if (!is.null(QueryObject$`layout`)) {
-        layoutObject <- Layout$new()
-        layoutObject$fromJSON(jsonlite::toJSON(QueryObject$layout, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #layoutObject <- Layout$new()
+        #layoutObject$fromJSON(jsonlite::toJSON(QueryObject$layout, auto_unbox = TRUE, digits = NA))
+        layoutObject <- Layout$new(QueryObject$layout)
         self$`layout` <- layoutObject
       }
       if (!is.null(QueryObject$`status`)) {
-        statusObject <- Querystatus$new()
-        statusObject$fromJSON(jsonlite::toJSON(QueryObject$status, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #statusObject <- Querystatus$new()
+        #statusObject$fromJSON(jsonlite::toJSON(QueryObject$status, auto_unbox = TRUE, digits = NA))
+        statusObject <- Querystatus$new(QueryObject$status)
         self$`status` <- statusObject
       }
       if (!is.null(QueryObject$`attributeBufferHeaders`)) {

--- a/R/query_reader.R
+++ b/R/query_reader.R
@@ -97,8 +97,14 @@ QueryReader <- R6::R6Class(
     fromJSON = function(QueryReaderJson) {
       QueryReaderObject <- jsonlite::fromJSON(QueryReaderJson)
       if (!is.null(QueryReaderObject$`layout`)) {
-        layoutObject <- Layout$new()
-        layoutObject$fromJSON(jsonlite::toJSON(QueryReaderObject$layout, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #layoutObject <- Layout$new()
+        #layoutObject$fromJSON(jsonlite::toJSON(QueryReaderObject$layout, auto_unbox = TRUE, digits = NA))
+        layoutObject <- Layout$new(QueryReaderObject$layout)
         self$`layout` <- layoutObject
       }
       if (!is.null(QueryReaderObject$`subarray`)) {

--- a/R/sql_parameters.R
+++ b/R/sql_parameters.R
@@ -122,8 +122,14 @@ SQLParameters <- R6::R6Class(
         self$`store_results` <- SQLParametersObject$`store_results`
       }
       if (!is.null(SQLParametersObject$`result_format`)) {
-        result_formatObject <- ResultFormat$new()
-        result_formatObject$fromJSON(jsonlite::toJSON(SQLParametersObject$result_format, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #result_formatObject <- ResultFormat$new()
+        #result_formatObject$fromJSON(jsonlite::toJSON(SQLParametersObject$result_format, auto_unbox = TRUE, digits = NA))
+        result_formatObject <- ResultFormat$new(SQLParametersObject$result_format)
         self$`result_format` <- result_formatObject
       }
       if (!is.null(SQLParametersObject$`init_commands`)) {

--- a/R/subarray.R
+++ b/R/subarray.R
@@ -55,8 +55,14 @@ Subarray <- R6::R6Class(
     fromJSON = function(SubarrayJson) {
       SubarrayObject <- jsonlite::fromJSON(SubarrayJson)
       if (!is.null(SubarrayObject$`layout`)) {
-        layoutObject <- Layout$new()
-        layoutObject$fromJSON(jsonlite::toJSON(SubarrayObject$layout, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #layoutObject <- Layout$new()
+        #layoutObject$fromJSON(jsonlite::toJSON(SubarrayObject$layout, auto_unbox = TRUE, digits = NA))
+        layoutObject <- Layout$new(SubarrayObject$layout)
         self$`layout` <- layoutObject
       }
       if (!is.null(SubarrayObject$`ranges`)) {

--- a/R/subarray_ranges.R
+++ b/R/subarray_ranges.R
@@ -65,8 +65,14 @@ SubarrayRanges <- R6::R6Class(
     fromJSON = function(SubarrayRangesJson) {
       SubarrayRangesObject <- jsonlite::fromJSON(SubarrayRangesJson)
       if (!is.null(SubarrayRangesObject$`type`)) {
-        typeObject <- Datatype$new()
-        typeObject$fromJSON(jsonlite::toJSON(SubarrayRangesObject$type, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #typeObject <- Datatype$new()
+        #typeObject$fromJSON(jsonlite::toJSON(SubarrayRangesObject$type, auto_unbox = TRUE, digits = NA))
+        typeObject <- Datatype$new(SubarrayRangesObject$type)
         self$`type` <- typeObject
       }
       if (!is.null(SubarrayRangesObject$`hasDefaultRange`)) {

--- a/R/udf_image.R
+++ b/R/udf_image.R
@@ -71,8 +71,14 @@ UDFImage <- R6::R6Class(
         self$`name` <- UDFImageObject$`name`
       }
       if (!is.null(UDFImageObject$`language`)) {
-        languageObject <- UDFLanguage$new()
-        languageObject$fromJSON(jsonlite::toJSON(UDFImageObject$language, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #languageObject <- UDFLanguage$new()
+        #languageObject$fromJSON(jsonlite::toJSON(UDFImageObject$language, auto_unbox = TRUE, digits = NA))
+        languageObject <- UDFLanguage$new(UDFImageObject$language)
         self$`language` <- languageObject
       }
       self

--- a/R/udf_info.R
+++ b/R/udf_info.R
@@ -127,13 +127,25 @@ UDFInfo <- R6::R6Class(
         self$`name` <- UDFInfoObject$`name`
       }
       if (!is.null(UDFInfoObject$`language`)) {
-        languageObject <- UDFLanguage$new()
-        languageObject$fromJSON(jsonlite::toJSON(UDFInfoObject$language, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #languageObject <- UDFLanguage$new()
+        #languageObject$fromJSON(jsonlite::toJSON(UDFInfoObject$language, auto_unbox = TRUE, digits = NA))
+        languageObject <- UDFLanguage$new(UDFInfoObject$language)
         self$`language` <- languageObject
       }
       if (!is.null(UDFInfoObject$`type`)) {
-        typeObject <- UDFType$new()
-        typeObject$fromJSON(jsonlite::toJSON(UDFInfoObject$type, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #typeObject <- UDFType$new()
+        #typeObject$fromJSON(jsonlite::toJSON(UDFInfoObject$type, auto_unbox = TRUE, digits = NA))
+        typeObject <- UDFType$new(UDFInfoObject$type)
         self$`type` <- typeObject
       }
       if (!is.null(UDFInfoObject$`readme`)) {

--- a/R/udf_info_update.R
+++ b/R/udf_info_update.R
@@ -157,8 +157,14 @@ UDFInfoUpdate <- R6::R6Class(
         self$`name` <- UDFInfoUpdateObject$`name`
       }
       if (!is.null(UDFInfoUpdateObject$`language`)) {
-        languageObject <- UDFLanguage$new()
-        languageObject$fromJSON(jsonlite::toJSON(UDFInfoUpdateObject$language, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #languageObject <- UDFLanguage$new()
+        #languageObject$fromJSON(jsonlite::toJSON(UDFInfoUpdateObject$language, auto_unbox = TRUE, digits = NA))
+        languageObject <- UDFLanguage$new(UDFInfoUpdateObject$language)
         self$`language` <- languageObject
       }
       if (!is.null(UDFInfoUpdateObject$`version`)) {
@@ -168,8 +174,14 @@ UDFInfoUpdate <- R6::R6Class(
         self$`image_name` <- UDFInfoUpdateObject$`image_name`
       }
       if (!is.null(UDFInfoUpdateObject$`type`)) {
-        typeObject <- UDFType$new()
-        typeObject$fromJSON(jsonlite::toJSON(UDFInfoUpdateObject$type, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #typeObject <- UDFType$new()
+        #typeObject$fromJSON(jsonlite::toJSON(UDFInfoUpdateObject$type, auto_unbox = TRUE, digits = NA))
+        typeObject <- UDFType$new(UDFInfoUpdateObject$type)
         self$`type` <- typeObject
       }
       if (!is.null(UDFInfoUpdateObject$`exec`)) {

--- a/R/udf_subarray.R
+++ b/R/udf_subarray.R
@@ -55,8 +55,14 @@ UDFSubarray <- R6::R6Class(
     fromJSON = function(UDFSubarrayJson) {
       UDFSubarrayObject <- jsonlite::fromJSON(UDFSubarrayJson)
       if (!is.null(UDFSubarrayObject$`layout`)) {
-        layoutObject <- Layout$new()
-        layoutObject$fromJSON(jsonlite::toJSON(UDFSubarrayObject$layout, auto_unbox = TRUE, digits = NA))
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # For enums, OpenAPI autogen (1) generates a constructor which requires being called
+        # with one arguent; (2) generates callsites (such as here) that calls that constructor
+        # with zero arguments.
+        #
+        #layoutObject <- Layout$new()
+        #layoutObject$fromJSON(jsonlite::toJSON(UDFSubarrayObject$layout, auto_unbox = TRUE, digits = NA))
+        layoutObject <- Layout$new(UDFSubarrayObject$layout)
         self$`layout` <- layoutObject
       }
       if (!is.null(UDFSubarrayObject$`ranges`)) {


### PR DESCRIPTION
Proactively grep-and-patch for more instances of https://github.com/TileDB-Inc/TileDB-Cloud-R/pull/91

Note the OpenAPI autogen has zero knobs for us to turn. Either we:

* after-patch its output like I'm doing, or
* submit a bug report to OpenAPI against its R generator and wait

At this point I've taken the former route.

Validation:

```
$ R
> devtools::load_all(); tinytest::test_all(".")
Loading tiledbcloud
Attaching package: 'tinytest'
test_a_delayed_1.R............   10 tests OK 1.1s
test_a_delayed_2.R............   28 tests OK 0.1s
test_a_delayed_3.R............    5 tests OK 2.4s
test_a_delayed_4.R............   10 tests OK 6.3s
test_b_array_info.R...........    3 tests OK 0.7s
test_b_array.R................    7 tests OK 0.8s
test_b_get_session.R..........    5 tests OK 0.2s
test_b_get_user.R.............    3 tests OK 0.3s
test_b_show_profile.R.........    6 tests OK 0.2s
test_b_sql.R..................    2 tests OK 3ms
test_c_udf_execution.R........   10 tests OK 31.8s
test_c_udf_reg_generic.R......    3 tests OK 1.4s
test_c_udf_reg_multi_array.R..    4 tests OK 7.3s
test_c_udf_reg_single_array.R.    5 tests OK 7.1s
test_d_delayed_5.R............    7 tests OK 49.6s
test_d_delayed_6.R............    8 tests OK 23.4s
test_d_delayed_7.R............    6 tests OK 19.4s
All ok, 122 results (18m 2.8s)
```