### PR TITLE
Escape double quotes inside exec_raw for UDF register

### DIFF
--- a/R/udf_info_update.R
+++ b/R/udf_info_update.R
@@ -251,9 +251,12 @@ UDFInfoUpdate <- R6::R6Class(
         if (!is.null(self$`exec_raw`)) {
         sprintf(
         '"exec_raw":
-          "%s"
+          %s
                 ',
-        self$`exec_raw`
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN: needs toJSON here to escape any double quotes inside
+        # the string, e.g. 'it is "ok" with me' -> "it is \"ok\" with me". Needs auto_unbox, else
+        # we get ["it is \"ok\" with me"] (note the [...]).
+        jsonlite::toJSON(self$exec_raw, auto_unbox=TRUE)
         )},
         if (!is.null(self$`readme`)) {
         sprintf(

--- a/inst/tinytest/test_c_udf_reg_generic.R
+++ b/inst/tinytest/test_c_udf_reg_generic.R
@@ -21,8 +21,8 @@ make_udf_name <- function(base) {
 
 # ================================================================
 udfname <- make_udf_name('udf-registration-test-generic')
-myfunc <- function(vec, exponent) {
-  sum(vec ** exponent)
+myfunc <- function(left, right) {
+  paste(left, "<=>", right)
 }
 
 # ----------------------------------------------------------------
@@ -35,14 +35,7 @@ registered_udf_name=paste(namespaceToCharge, udfname, sep='/')
 
 result <- tiledbcloud::execute_generic_udf(
   registered_udf_name=registered_udf_name,
-  args=list(vec=1:10, exponent=2),
-  namespace=namespaceToCharge
-)
-expect_equal(result, 385)
-
-result <- tiledbcloud::execute_generic_udf(
-  registered_udf_name=registered_udf_name,
-  args=list(vec=1:10, exponent=3),
+  args=list(left="left", right="right"),
   namespace=namespaceToCharge
 )
 
@@ -50,4 +43,4 @@ result <- tiledbcloud::execute_generic_udf(
 # so we don't leave temp names dangling.
 tiledbcloud::deregister_udf(namespace=namespaceToCharge, name=udfname)
 
-expect_equal(result, 3025)
+expect_equal(result, "left <=> right")


### PR DESCRIPTION
For registering UDFs we send along the R-serialized UDF, along with a raw string of the UDF source -- for things like the Preview tab in TileDB Cloud.

In an embarrassing lack of earlier test coverage, I found during notebook work today that double quotes inside function bodies were being incorrectly escaped as JSON, resulting in a parse error server-side, along with a failure to register the UDF.