### PR TITLE
Handle newlines embedded in SQL query strings

### DIFF
--- a/R/sql_parameters.R
+++ b/R/sql_parameters.R
@@ -50,7 +50,11 @@ SQLParameters <- R6::R6Class(
       }
       if (!is.null(`query`)) {
         stopifnot(is.character(`query`), length(`query`) == 1)
-        self$`query` <- `query`
+        # MANUAL EDIT AFTER OPENAPI AUTOGEN
+        # Avoid this:
+        # Error: tiledbcloud: received error response: Server returned 400 response status code.
+        # Message:  could not parse request body: invalid character '\n' in string literal
+        self$`query` <- gsub("\n", " ", `query`)
       }
       if (!is.null(`output_uri`)) {
         stopifnot(is.character(`output_uri`), length(`output_uri`) == 1)

--- a/inst/tinytest/test_b_sql.R
+++ b/inst/tinytest/test_b_sql.R
@@ -18,6 +18,11 @@ expect_true(is(sql, "SqlApi"))
 sqlpar <-  SQLParameters$new(name="ArbitraryNameHere", query=paste("select 1 as one"))
 expect_true(is(sqlpar, "SQLParameters"))
 
+# Check for handling of newlines inside SQL-query strings
+sqlpar <-  SQLParameters$new(name="ArbitraryNameHere", query=paste("select 2
+as two"))
+expect_true(is(sqlpar, "SQLParameters"))
+
 if (FALSE) {
     ## these work in isolation i.e. via run_test_file() but not in the test env; unsure why
     ans <- sql$RunSQL("unittest", sqlpar)


### PR DESCRIPTION
Found during notebook work