### PR TITLE
Improve manual layer for get-user API call

### DIFF
--- a/R/manual_layer_login.R
+++ b/R/manual_layer_login.R
@@ -79,7 +79,11 @@ login <- function(username, password, api_key, host, remember_me=TRUE, write_con
     }
 
     ## Use as a possible test.
-    res <- userApiInstance$GetUser()
+    resultObject <- userApiInstance$GetUser()
+    # Decode the result
+    body <- .get_raw_response_body_or_stop(resultObject)
+    res <- jsonlite::fromJSON(rawToChar(body))
+
     if (verbose) cat("GetUser() got name", res$name, "\n")
 
     ## We do not store username and password, but update.

--- a/R/manual_layer_user.R
+++ b/R/manual_layer_user.R
@@ -18,7 +18,14 @@ user_profile <- function(include_logo=FALSE) {
   apiClientInstance <- get_api_client_instance()
   userApiInstance <- UserApi$new(apiClientInstance)
 
-  info <- userApiInstance$GetUser()
+  resultObject <- userApiInstance$GetUser()
+  # Decode the result
+  body <- .get_raw_response_body_or_stop(resultObject)
+  info <- jsonlite::fromJSON(rawToChar(body))
+
+  cat("WTF----------------------------------------------------------------\n")
+  str(info)
+  cat("WTF----------------------------------------------------------------\n")
   if (!include_logo) {
     info[["logo"]] <- NULL
   }

--- a/R/user_api.R
+++ b/R/user_api.R
@@ -1700,13 +1700,10 @@ UserApi <- R6::R6Class(
     GetUser = function(...){
       apiResponse <- self$GetUserWithHttpInfo(...)
       resp <- apiResponse$response
+      # MANUAL EDIT AFTER OPENAPI AUTOGEN
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         apiResponse$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        apiResponse
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        apiResponse
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else {
         apiResponse
       }
     },
@@ -1732,21 +1729,8 @@ UserApi <- R6::R6Class(
                                  body = body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
-        deserializedRespObj <- tryCatch(
-          self$apiClient$deserialize(resp, "User", loadNamespace("tiledbcloud")),
-          error = function(e){
-             stop("Failed to deserialize response")
-          }
-        )
-        ApiResponse$new(deserializedRespObj, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        ApiResponse$new(paste("Server returned " , httr::status_code(resp) , " response status code."), resp)
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        ApiResponse$new("API client error", resp)
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        ApiResponse$new("API server error", resp)
-      }
+      # MANUAL EDIT AFTER OPENAPI AUTOGEN
+      .wrap_as_api_response(resp)
     },
     GetUserWithUsername = function(username, ...){
       apiResponse <- self$GetUserWithUsernameWithHttpInfo(username, ...)

--- a/inst/tinytest/test_b_get_session.R
+++ b/inst/tinytest/test_b_get_session.R
@@ -12,7 +12,7 @@ if (is.null(userApiInstance)) exit_file("not logged in")
 
 res <- userApiInstance$GetSession()
 expect_true(is(res, "Token"))
-expect_true(is.character(res$token))
+expect_true(!is.null(res$token) && is.character(res$token))
 
 getUTC <- function(x) as.POSIXct(x, tz="UTC", format="%Y-%m-%dT%H:%M:%OS")
 issued <- getUTC(res$issued_at)

--- a/inst/tinytest/test_b_get_user.R
+++ b/inst/tinytest/test_b_get_user.R
@@ -16,10 +16,12 @@ res <- userApiInstance$GetUser()
 expect_true(is.list(res))
 expect_true(length(names(res)) >= 13)
 expect_equal(res$is_valid_email, TRUE)
-if (res$email == "aws-mvp@tiledb.io") {
-    # local environment variable can get in the way while developing
-    expect_equal(res$email, "aws-mvp@tiledb.io")
-    expect_equal(res$name, "Unit Test")
-    expect_equal(res$username, "unittest")
-    expect_equal(res$organizations$username, "unittest")
+if (!is.null(res$email)) {
+  if (res$email == "aws-mvp@tiledb.io") {
+      # local environment variable can get in the way while developing
+      expect_equal(res$email, "aws-mvp@tiledb.io")
+      expect_equal(res$name, "Unit Test")
+      expect_equal(res$username, "unittest")
+      expect_equal(res$organizations$username, "unittest")
+  }
 }


### PR DESCRIPTION
More in the vein of #58, #42, etc etc -- issue is that OpenAPI autogen code just says `ApiResponse` on error; we need to adapt callsites to print out actual server-side errors. Found during sandbox testing.