### PR TITLE
Neaten some unit-test files with regard to recent PRs

### DIFF
--- a/R/manual_layer_user.R
+++ b/R/manual_layer_user.R
@@ -23,9 +23,6 @@ user_profile <- function(include_logo=FALSE) {
   body <- .get_raw_response_body_or_stop(resultObject)
   info <- jsonlite::fromJSON(rawToChar(body))
 
-  cat("WTF----------------------------------------------------------------\n")
-  str(info)
-  cat("WTF----------------------------------------------------------------\n")
   if (!include_logo) {
     info[["logo"]] <- NULL
   }

--- a/inst/tinytest/test_b_get_user.R
+++ b/inst/tinytest/test_b_get_user.R
@@ -9,10 +9,7 @@ if ((unitTestToken <- Sys.getenv("TILEDB_REST_UNIT_TEST_TOKEN")) != "") {
 library(tiledbcloud)
 library(tinytest)
 
-userApiInstance <- tiledbcloud:::.pkgenv[["userApiInstance"]]
-if (is.null(userApiInstance)) exit_file("not logged in")
-
-res <- userApiInstance$GetUser()
+res <- user_profile()
 expect_true(is.list(res))
 expect_true(length(names(res)) >= 13)
 expect_equal(res$is_valid_email, TRUE)

--- a/inst/tinytest/test_d_delayed_7.R
+++ b/inst/tinytest/test_d_delayed_7.R
@@ -37,14 +37,12 @@ library(tiledbcloud)
 # Non-delayed
 o <- execute_generic_udf(
   registered_udf_name='johnkerl-tiledb/tiledb-cloud-r-generic-udf-r',
-  args=list(vec=1:16, exponent=3),
-  namespace=namespaceToCharge
+  args=list(vec=1:16, exponent=3)
 )
 expect_equal(o, 18496)
 
 # Delayed
 a <- delayed_generic_udf(
-  namespace=namespaceToCharge,
   registered_udf_name='johnkerl-tiledb/tiledb-cloud-r-generic-udf-r',
   args=list(vec=1:16, exponent=3),
   name='my generic udf'
@@ -72,14 +70,12 @@ o <- execute_array_udf(
   registered_udf_name='johnkerl-tiledb/tiledb-cloud-r-single-array-udf-r',
   selectedRanges=list(cbind(1,4), cbind(1,4)),
   attrs=c("a"),
-  args=list(attr="a", exponent=3),
-  namespace=namespaceToCharge
+  args=list(attr="a", exponent=3)
 )
 expect_equal(o, 18496)
 
 # Delayed
 a <- delayed_array_udf(
-  namespace=namespaceToCharge,
   array="TileDB-Inc/quickstart_dense",
   registered_udf_name='johnkerl-tiledb/tiledb-cloud-r-single-array-udf-r',
   selectedRanges=list(cbind(1,4), cbind(1,4)),
@@ -109,14 +105,12 @@ expect_equal(o, 18496)
 o <- execute_generic_udf(
   registered_udf_name='johnkerl-tiledb/tiledb-cloud-r-generic-udf-py',
   args=list(vec=1:16, exponent=3),
-  namespace=namespaceToCharge,
   language='python'
 )
 expect_equal(o, 18496)
 
 # Delayed
 a <- delayed_generic_udf(
-  namespace=namespaceToCharge,
   registered_udf_name='johnkerl-tiledb/tiledb-cloud-r-generic-udf-py',
   args=list(vec=1:16, exponent=3),
   name='my generic udf',
@@ -139,8 +133,6 @@ expect_equal(o, 18496)
 #   return int(numpy.sum(df[attr] ** exponent))
 # tiledb.cloud.udf.register_single_array_udf(myfunc, name="tiledb-cloud-r-single-array-udf-py", namespace="johnkerl-tiledb")
 
-# PENDING https://github.com/TileDB-Inc/TileDB-REST-UDF-Docker-Images/pull/213
-
 # Non-delayed
 o <- execute_array_udf(
   array="TileDB-Inc/quickstart_dense",
@@ -148,14 +140,12 @@ o <- execute_array_udf(
   selectedRanges=list(cbind(1,4), cbind(1,4)),
   attrs=c("a"),
   args=list(attr="a", exponent=3),
-  namespace=namespaceToCharge,
   language='python'
 )
 expect_equal(o, 18496)
 
 # Delayed
 a <- delayed_array_udf(
-  namespace=namespaceToCharge,
   array="TileDB-Inc/quickstart_dense",
   registered_udf_name='johnkerl-tiledb/tiledb-cloud-r-single-array-udf-py',
   selectedRanges=list(cbind(1,4), cbind(1,4)),
@@ -163,5 +153,5 @@ a <- delayed_array_udf(
   args=list(attr="a", exponent=3),
   language='python'
 )
-o <- compute(a, namespace=namespaceToCharge)
+o <- compute(a)
 expect_equal(o, 18496)


### PR DESCRIPTION
* `namespace` arguments no longer required as of #95 / #98
* Incorporate #99 into unit-test call