### PR TITLE
Double-check namespace non-null on UDF exec

### DIFF
--- a/R/manual_layer_udf.R
+++ b/R/manual_layer_udf.R
@@ -44,7 +44,7 @@ execute_generic_udf <- function(udf=NULL, registered_udf_name=NULL, args=NULL, r
   args_format='native', namespace=NULL, language='r')
 {
   if (is.null(namespace)) {
-    namespace <- .get_default_namespace_charged()
+    namespace <- .get_default_namespace_charged_or_stop()
   }
   apiClientInstance <- get_api_client_instance()
   udfApiInstance <- UdfApi$new(apiClientInstance)
@@ -158,7 +158,7 @@ execute_array_udf <- function(array, udf=NULL, registered_udf_name=NULL, selecte
   result_format='native', args_format='native', namespace=NULL, language='r')
 {
   if (is.null(namespace)) {
-    namespace <- .get_default_namespace_charged()
+    namespace <- .get_default_namespace_charged_or_stop()
   }
   apiClientInstance <- get_api_client_instance()
   udfApiInstance <- UdfApi$new(apiClientInstance)
@@ -293,7 +293,7 @@ execute_multi_array_udf <- function(array_list, udf=NULL, registered_udf_name=NU
   result_format='native', args_format='native', namespace=NULL, language='r')
 {
   if (is.null(namespace)) {
-    namespace <- .get_default_namespace_charged()
+    namespace <- .get_default_namespace_charged_or_stop()
   }
   apiClientInstance <- get_api_client_instance()
   udfApiInstance <- UdfApi$new(apiClientInstance)


### PR DESCRIPTION
Already added is a check that if arg `namespace` is `NULL` on UDF exec, get the default from the current logged-in user. What's lacking is checking if _that_ is null. This never surfaced before in staging/prod use since there my accounts have defaults. This arose in some one-off sandbox testing where my account doesn't have a default.

Without this PR, if an account doesn't have a default namespace, and if no namespace is supplied in the UDF-execute call, the user sees a very cryptic error messagge.

```
Error in gsub(paste0("\\{", "namespace", "\\}"), URLencode(as.character(namespace),  :
  invalid 'replacement' argument
```

With this PR:

```
Error in .get_default_namespace_charged_or_stop() :
  namespace was not provided, and no account-local default was found
```