### PR TITLE
Send language version on UDF register

### DIFF
--- a/R/manual_layer_udf.R
+++ b/R/manual_layer_udf.R
@@ -388,6 +388,10 @@ register_udf <- function(namespace=NULL, name, type, func, func_text=NULL, versi
     func_text <- paste(deparse(func), collapse="\\n")
   }
 
+  if (is.null(version)) {
+    version <- .set_udf_version('r')
+  }
+
   info <- tiledbcloud::UDFInfoUpdate$new(
     name=name,
     type=tiledbcloud::UDFType$new(type),

--- a/R/udf_api.R
+++ b/R/udf_api.R
@@ -858,7 +858,7 @@ UdfApi <- R6::R6Class(
       }
 
       urlPath <- "/udfs/generic/{namespace}"
-      if (!missing(`namespace`)) {
+      if (!is.null(`namespace`)) {
         urlPath <- gsub(paste0("\\{", "namespace", "\\}"), URLencode(as.character(`namespace`), reserved = TRUE), urlPath)
       }
 


### PR DESCRIPTION
This goes with a recent server-side mod for tracking UDF language versions.

For Python:

* That was a big deal, as function-pickling is dependent on Python version
* `TileDB-Cloud-Py` has long sent language version on UDF register and UDF execute

For R:

* This is not a big deal, as R serialization isn't dependent on R version
* `TileDB-Cloud-R` has been sending language version on UDF execute but not (until now) on UDF registration

This is just for completeness -- no user-visible behavor is broken, or fixed, by this PR.