### PR TITLE
0.10.0 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tiledbcloud
 Type: Package
 Title: TileDB Cloud Platform R Client Package
-Version: 0.0.9
+Version: 0.0.10
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
              person("OpenAPI Generator community", email = "team@openapitools.org", role = "ctb"),
              person("John", "Kerl", email = "john.kerl@tiledb.com", role="cre"))


### PR DESCRIPTION
I'll use this commit to tag the next release. Note that R has (for historical reasons, as it's much older than GitHub) its own version-numbering -- which is bumped here.

Once this is tagged and pushed to our JupyterHub system, I'll be able to close out docmods at https://docs.tiledb.com/cloud/api-reference/array-access.