### PR TITLE
Add new `ResultFormat` values to generated R code.

### DIFF
--- a/R/result_format.R
+++ b/R/result_format.R
@@ -67,7 +67,7 @@ ResultFormat <- R6::R6Class(
 # add to utils.R
 .parse_ResultFormat <- function(vals) {
     res <- gsub("^\\[|\\]$", "",
-        "[native, json, arrow]"
+        "[python_pickle, r_serialization, json, arrow, bytes, tiledb_json, native]"
     )
     unlist(strsplit(res, ", "))
 }


### PR DESCRIPTION
The UDF environment still doesn't seem to understand `r_serialization`
as a serialization format despite it being in the serialization
switch-block. So maybe adding it here will help?

I did this edit manually rather than running the generator script
because, given all the postprocessing, using the script frightens and
confuses me.