### PR TITLE
Make unit tests work as non-unittest user

### DIFF
--- a/inst/tinytest/README.txt
+++ b/inst/tinytest/README.txt
@@ -1,4 +1,3 @@
-Names of files in this directory are intended to first test things not
-requiring a TileDB account, then test things requiring a TileDB account .  As
-well, DAG execution of UDFs is intended to be tested after non-DAG execution of
-UDFs.
+Names of files in this directory are intended to first test things not requiring
+a TileDB account, then test things requiring a TileDB account.  As well, DAG
+execution of UDFs is intended to be tested after non-DAG execution of UDFs.

--- a/inst/tinytest/test_a_delayed_4.R
+++ b/inst/tinytest/test_a_delayed_4.R
@@ -1,6 +1,6 @@
-## ================================================================
-## See comments on test_delayed_1.R regarding filenames for these test cases.
-## ================================================================
+# ================================================================
+# See comments on test_delayed_1.R regarding filenames for these test cases.
+# ================================================================
 
 library(tiledbcloud)
 library(tinytest)

--- a/inst/tinytest/test_b_array.R
+++ b/inst/tinytest/test_b_array.R
@@ -1,3 +1,6 @@
+# ================================================================
+# See comments on test_delayed_1.R regarding filenames for these test cases.
+# ================================================================
 
 library(tiledbcloud)
 library(tinytest)

--- a/inst/tinytest/test_b_array_info.R
+++ b/inst/tinytest/test_b_array_info.R
@@ -1,3 +1,6 @@
+# ================================================================
+# See comments on test_delayed_1.R regarding filenames for these test cases.
+# ================================================================
 
 library(tiledbcloud)
 library(tinytest)

--- a/inst/tinytest/test_b_get_session.R
+++ b/inst/tinytest/test_b_get_session.R
@@ -1,3 +1,6 @@
+# ================================================================
+# See comments on test_delayed_1.R regarding filenames for these test cases.
+# ================================================================
 
 library(tiledbcloud)
 library(tinytest)

--- a/inst/tinytest/test_b_get_user.R
+++ b/inst/tinytest/test_b_get_user.R
@@ -1,3 +1,6 @@
+# ================================================================
+# See comments on test_delayed_1.R regarding filenames for these test cases.
+# ================================================================
 
 library(tiledbcloud)
 library(tinytest)

--- a/inst/tinytest/test_b_show_profile.R
+++ b/inst/tinytest/test_b_show_profile.R
@@ -1,3 +1,6 @@
+# ================================================================
+# See comments on test_delayed_1.R regarding filenames for these test cases.
+# ================================================================
 
 library(tiledbcloud)
 library(tinytest)

--- a/inst/tinytest/test_b_sql.R
+++ b/inst/tinytest/test_b_sql.R
@@ -1,3 +1,6 @@
+# ================================================================
+# See comments on test_delayed_1.R regarding filenames for these test cases.
+# ================================================================
 
 library(tiledbcloud)
 library(tinytest)

--- a/inst/tinytest/test_c_udf_execution.R
+++ b/inst/tinytest/test_c_udf_execution.R
@@ -1,3 +1,6 @@
+# ================================================================
+# See comments on test_delayed_1.R regarding filenames for these test cases.
+# ================================================================
 
 if ((namespaceToCharge <- Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE")) == "") {
     exit_file("No TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE in environment")

--- a/inst/tinytest/test_c_udf_reg_generic.R
+++ b/inst/tinytest/test_c_udf_reg_generic.R
@@ -1,3 +1,6 @@
+# ================================================================
+# See comments on test_delayed_1.R regarding filenames for these test cases.
+# ================================================================
 
 if ((namespaceToCharge <- Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE")) == "") {
     exit_file("No TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE in environment")

--- a/inst/tinytest/test_c_udf_reg_multi_array.R
+++ b/inst/tinytest/test_c_udf_reg_multi_array.R
@@ -1,3 +1,6 @@
+# ================================================================
+# See comments on test_delayed_1.R regarding filenames for these test cases.
+# ================================================================
 
 if ((namespaceToCharge <- Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE")) == "") {
     exit_file("No TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE in environment")

--- a/inst/tinytest/test_c_udf_reg_single_array.R
+++ b/inst/tinytest/test_c_udf_reg_single_array.R
@@ -1,3 +1,6 @@
+# ================================================================
+# See comments on test_delayed_1.R regarding filenames for these test cases.
+# ================================================================
 
 if ((namespaceToCharge <- Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE")) == "") {
     exit_file("No TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE in environment")

--- a/inst/tinytest/test_d_delayed_7.R
+++ b/inst/tinytest/test_d_delayed_7.R
@@ -15,6 +15,11 @@ if ((namespaceToCharge <- Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE"
 }
 
 # ----------------------------------------------------------------
+if (Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE") != "unittest") {
+    exit_file("Skipping unit tests which use resources for TileDB Cloud unittest account")
+}
+
+# ----------------------------------------------------------------
 library(tiledbcloud)
 
 # ----------------------------------------------------------------

--- a/inst/tinytest/test_d_delayed_7.R
+++ b/inst/tinytest/test_d_delayed_7.R
@@ -16,7 +16,7 @@ if ((namespaceToCharge <- Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE"
 
 # ----------------------------------------------------------------
 if (Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE") != "unittest") {
-    exit_file("Skipping unit tests which use resources for TileDB Cloud unittest account")
+    exit_file("Skipping unit tests which use resources specific to the TileDB Cloud unittest account")
 }
 
 # ----------------------------------------------------------------

--- a/inst/tinytest/test_e_register_array.R
+++ b/inst/tinytest/test_e_register_array.R
@@ -1,3 +1,7 @@
+# ================================================================
+# See comments on test_delayed_1.R regarding filenames for these test cases.
+# ================================================================
+
 if ((namespaceToCharge <- Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE")) == "") {
     exit_file("No TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE in environment")
 }
@@ -8,6 +12,11 @@ library(tinytest)
 # ----------------------------------------------------------------
 cloud_config <- tiledbcloud::configure()
 if (!tiledbcloud:::.logged_in()) exit_file("not logged in")
+
+# ----------------------------------------------------------------
+if (Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE") != "unittest") {
+    exit_file("Skipping unit tests which use resources for TileDB Cloud unittest account")
+}
 
 # ----------------------------------------------------------------
 make_temp_array_name <- function(base) {

--- a/inst/tinytest/test_e_register_array.R
+++ b/inst/tinytest/test_e_register_array.R
@@ -15,7 +15,7 @@ if (!tiledbcloud:::.logged_in()) exit_file("not logged in")
 
 # ----------------------------------------------------------------
 if (Sys.getenv("TILEDB_REST_UNIT_TEST_NAMESPACE_TO_CHARGE") != "unittest") {
-    exit_file("Skipping unit tests which use resources for TileDB Cloud unittest account")
+    exit_file("Skipping unit tests which use resources specific to the TileDB Cloud unittest account")
 }
 
 # ----------------------------------------------------------------


### PR DESCRIPTION
Follow-on to #115:

* Before #115, unit tests worked only in sandbox
* After #115, they work in CI for the `unittest` account ...
* ... but _only_ for that account
* On this PR we skip tests which require precooked data particular to the `unittest` account, outside of CI

Validation:

* CI run for this PR
* `Rscript -e 'tinytest::test_all(".")'` from my sandbox