### PR TITLE
Add test for login to test script matching earlier test scripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Bootstrap
         run: ./.github/r-ci.sh bootstrap

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -15,7 +15,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-pandoc@v1
 

--- a/inst/tinytest/test_b_get_user.R
+++ b/inst/tinytest/test_b_get_user.R
@@ -5,6 +5,9 @@
 library(tiledbcloud)
 library(tinytest)
 
+userApiInstance <- tiledbcloud:::.pkgenv[["userApiInstance"]]
+if (is.null(userApiInstance)) exit_file("not logged in")
+
 res <- user_profile()
 expect_true(is.list(res))
 expect_true(length(names(res)) >= 13)


### PR DESCRIPTION
This PR adds a simple 'do we have a working login?' clause to another test files---mirroring what the other test files already have.  When this is added, the whole test setup (as run by `tinytest`, as opposed to the other auto-added by OpenAPI using `testthat`) passes for me in a container without any environment variables or authentication tokens.

So this may be enough to unblock the (currently failing over failing tests) [build at r-universe](https://tiledb-inc.r-universe.dev/builds)

No new code.