### PR TITLE
Return arrow table from UDFs where result_format=arrow

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tiledbcloud
 Type: Package
 Title: TileDB Cloud Platform R Client Package
-Version: 0.0.10.2
+Version: 0.0.10.3
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
              person("OpenAPI Generator community", email = "team@openapitools.org", role = "ctb"),
              person("John", "Kerl", email = "john.kerl@tiledb.com", role="cre"))

--- a/R/manual_layer_responses.R
+++ b/R/manual_layer_responses.R
@@ -151,7 +151,7 @@
     },
     arrow={
       stopifnot("The 'arrow' package is required." = requireNamespace("arrow", quietly=TRUE))
-      decoded_response <- arrow::read_ipc_stream(body)
+      decoded_response <- arrow::read_ipc_stream(body, as_data_frame = FALSE)
     },
     stop("Result format unrecognized: ", result_format)
   )

--- a/inst/tinytest/test_c_udf_execution.R
+++ b/inst/tinytest/test_c_udf_execution.R
@@ -51,7 +51,7 @@ expect_equal(result$result, c(300, 302, 304, 306, 308))
 # Exercise resource_class
 
 result <- tiledbcloud::execute_generic_udf(udf=myfunc, args=myargs, result_format='arrow', namespace=namespaceToCharge, resource_class="large")
-expect_equal(result$result, c(300, 302, 304, 306, 308))
+expect_equal(result$result$as_vector(), c(300, 302, 304, 306, 308))
 
 expect_error(
   tiledbcloud::execute_generic_udf(udf=myfunc, args=myargs, result_format='arrow', namespace=namespaceToCharge, resource_class="nonesuch")
@@ -142,7 +142,7 @@ result <- tiledbcloud::execute_array_udf(
   namespace=namespaceToCharge
 )
 # Arrow result is of type dataframe, so we pull out the 'result' slot
-expect_equal(result$result, 18496)
+expect_equal(result$result$as_vector(), 18496)
 
 # Exercise resource_class
 result <- tiledbcloud::execute_array_udf(
@@ -156,7 +156,7 @@ result <- tiledbcloud::execute_array_udf(
   resource_class="large"
 )
 # Arrow result is of type dataframe, so we pull out the 'result' slot
-expect_equal(result$result, 18496)
+expect_equal(result$result$as_vector(), 18496)
 
 expect_error(
   tiledbcloud::execute_array_udf(


### PR DESCRIPTION
This modifies the internal `.get_decoded_response_body_or_stop()` method used by `execute_multi_array_udf()`, `execute_array_udf()`, and `execute_generic_udf()` to return an Arrow Table when `result_format = "arrow"`, rather than forcing conversion to a `data.frame`. 

I believe the CI failure is unrelated to this PR as [manually running it on `master`](https://github.com/TileDB-Inc/TileDB-Cloud-R/actions/runs/5592676733/jobs/10225437509) produces the same failure.